### PR TITLE
refactor: tailwind custom color를 정의 및 적용한다.

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -3,77 +3,114 @@
 @tailwind utilities;
 
 @font-face {
-    font-family: 'Pretendard';
-    src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Thin.woff') format('woff');
-    font-weight: 100;
-    font-style: normal;
+  font-family: "Pretendard";
+  src: url("https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Thin.woff")
+    format("woff");
+  font-weight: 100;
+  font-style: normal;
 }
 
 @font-face {
-    font-family: 'Pretendard';
-    src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-ExtraLight.woff') format('woff');
-    font-weight: 200;
-    font-style: normal;
+  font-family: "Pretendard";
+  src: url("https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-ExtraLight.woff")
+    format("woff");
+  font-weight: 200;
+  font-style: normal;
 }
 
 @font-face {
-    font-family: 'Pretendard';
-    src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Light.woff') format('woff');
-    font-weight: 300;
-    font-style: normal;
+  font-family: "Pretendard";
+  src: url("https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Light.woff")
+    format("woff");
+  font-weight: 300;
+  font-style: normal;
 }
 
 @font-face {
-    font-family: 'Pretendard';
-    src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
-    font-weight: 400;
-    font-style: normal;
+  font-family: "Pretendard";
+  src: url("https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff")
+    format("woff");
+  font-weight: 400;
+  font-style: normal;
 }
 
 @font-face {
-    font-family: 'Pretendard';
-    src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Medium.woff') format('woff');
-    font-weight: 500;
-    font-style: normal;
+  font-family: "Pretendard";
+  src: url("https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Medium.woff")
+    format("woff");
+  font-weight: 500;
+  font-style: normal;
 }
 
 @font-face {
-    font-family: 'Pretendard';
-    src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-SemiBold.woff') format('woff');
-    font-weight: 600;
-    font-style: normal;
+  font-family: "Pretendard";
+  src: url("https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-SemiBold.woff")
+    format("woff");
+  font-weight: 600;
+  font-style: normal;
 }
 
 @font-face {
-    font-family: 'Pretendard';
-    src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Bold.woff') format('woff');
-    font-weight: 700;
-    font-style: normal;
+  font-family: "Pretendard";
+  src: url("https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Bold.woff")
+    format("woff");
+  font-weight: 700;
+  font-style: normal;
 }
 
 @font-face {
-    font-family: 'Pretendard';
-    src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-ExtraBold.woff') format('woff');
-    font-weight: 800;
-    font-style: normal;
+  font-family: "Pretendard";
+  src: url("https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-ExtraBold.woff")
+    format("woff");
+  font-weight: 800;
+  font-style: normal;
 }
 
 @font-face {
-    font-family: 'Pretendard';
-    src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Black.woff') format('woff');
-    font-weight: 900;
-    font-style: normal;
+  font-family: "Pretendard";
+  src: url("https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Black.woff")
+    format("woff");
+  font-weight: 900;
+  font-style: normal;
 }
 
 * {
-    font-family: 'pretendard', -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
+  font-family:
+    "pretendard",
+    -apple-system,
+    BlinkMacSystemFont,
+    system-ui,
+    Roboto,
+    "Helvetica Neue",
+    "Segoe UI",
+    "Apple SD Gothic Neo",
+    "Noto Sans KR",
+    "Malgun Gothic",
+    "Apple Color Emoji",
+    "Segoe UI Emoji",
+    "Segoe UI Symbol",
+    sans-serif;
 }
 helvetica {
-    font-family: 'Helvetica', 'sans-serif'
+  font-family: "Helvetica", "sans-serif";
 }
 
-pre{
-  font-family: 'pretendard', -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
+pre {
+  font-family:
+    "pretendard",
+    -apple-system,
+    BlinkMacSystemFont,
+    system-ui,
+    Roboto,
+    "Helvetica Neue",
+    "Segoe UI",
+    "Apple SD Gothic Neo",
+    "Noto Sans KR",
+    "Malgun Gothic",
+    "Apple Color Emoji",
+    "Segoe UI Emoji",
+    "Segoe UI Symbol",
+    sans-serif;
 }
 
 @layer base {
@@ -82,7 +119,7 @@ pre{
     -webkit-appearance: none;
     margin: 0;
   }
-  div::-webkit-scrollbar{
+  div::-webkit-scrollbar {
     display: none;
   }
 }

--- a/frontend/components/admin/Board.component.tsx
+++ b/frontend/components/admin/Board.component.tsx
@@ -63,7 +63,7 @@ const InterViewerUpdateButton: FC<InterViewerUpdateButtonProps> = ({
       className={classNames(
         "py-2 w-[6rem] rounded-md",
         user.role === role
-          ? "bg-[#CEDCFF] text-[#2160FF]"
+          ? "bg-[#CEDCFF] text-primary"
           : "bg-[#EDEDED] text-[#B5B5B5]"
       )}
     >

--- a/frontend/components/admin/Board.component.tsx
+++ b/frontend/components/admin/Board.component.tsx
@@ -64,7 +64,7 @@ const InterViewerUpdateButton: FC<InterViewerUpdateButtonProps> = ({
         "py-2 w-[6rem] rounded-md",
         user.role === role
           ? "bg-[#CEDCFF] text-primary"
-          : "bg-light text-[#B5B5B5]"
+          : "bg-light text-secondary-100"
       )}
     >
       {roleTranslater(role)}
@@ -99,12 +99,12 @@ const AdminBoard = () => {
         <div className="flex py-4 justify-between">
           <Txt
             typography="h6"
-            className="flex-[1_0_0] text-left text-[#B5B7C0]"
+            className="flex-[1_0_0] text-left text-secondary-100"
           >
             Member Name
           </Txt>
-          <Txt className="flex-[2_0_0] text-left text-[#B5B7C0]">기수</Txt>
-          <Txt className="w-[28.5rem] text-left text-[#B5B7C0]">Status</Txt>
+          <Txt className="flex-[2_0_0] text-left text-secondary-100">기수</Txt>
+          <Txt className="w-[28.5rem] text-left text-secondary-100">Status</Txt>
         </div>
       </div>
       {userData.map((user, index) => (

--- a/frontend/components/admin/Board.component.tsx
+++ b/frontend/components/admin/Board.component.tsx
@@ -64,7 +64,7 @@ const InterViewerUpdateButton: FC<InterViewerUpdateButtonProps> = ({
         "py-2 w-[6rem] rounded-md",
         user.role === role
           ? "bg-[#CEDCFF] text-primary"
-          : "bg-[#EDEDED] text-[#B5B5B5]"
+          : "bg-light text-[#B5B5B5]"
       )}
     >
       {roleTranslater(role)}

--- a/frontend/components/admin/Board.component.tsx
+++ b/frontend/components/admin/Board.component.tsx
@@ -63,7 +63,7 @@ const InterViewerUpdateButton: FC<InterViewerUpdateButtonProps> = ({
       className={classNames(
         "py-2 w-[6rem] rounded-md",
         user.role === role
-          ? "bg-[#CEDCFF] text-primary"
+          ? "bg-primary-300 text-primary"
           : "bg-light text-secondary-100"
       )}
     >

--- a/frontend/components/applicant/Search.component.tsx
+++ b/frontend/components/applicant/Search.component.tsx
@@ -5,7 +5,7 @@ const ApplicantSearch = () => {
         <img src="/icons/search-icon.svg" alt="search" />
       </button>
       <input
-        className="p-2 color-[#B5B7C0] bg-transparent outline-none"
+        className="p-2 color-secondary-100 bg-transparent outline-none"
         type="text"
         placeholder="search"
       ></input>

--- a/frontend/components/applicant/Search.component.tsx
+++ b/frontend/components/applicant/Search.component.tsx
@@ -1,6 +1,6 @@
 const ApplicantSearch = () => {
   return (
-    <form className="flex items-center py-2 px-4 bg-[#F9FBFF] rounded-2xl gap-2">
+    <form className="flex items-center py-2 px-4 bg-primary-100 rounded-2xl gap-2">
       <button>
         <img src="/icons/search-icon.svg" alt="search" />
       </button>

--- a/frontend/components/applicant/applicantNode/CustomResource.component.tsx
+++ b/frontend/components/applicant/applicantNode/CustomResource.component.tsx
@@ -14,7 +14,7 @@ const ApplicantResource: FC<ApplicantResourceProps> = ({ data, postId }) => {
   return (
     <>
       <div className="flex flex-col gap-1 mb-2">
-        <Txt className="text-xl text-[#666] font-medium">
+        <Txt className="text-xl text-secondary-200 font-medium">
           {applicantDataFinder(data, "major")}
         </Txt>
         <Txt typography="h2">{`[${applicantDataFinder(
@@ -22,7 +22,7 @@ const ApplicantResource: FC<ApplicantResourceProps> = ({ data, postId }) => {
           "field"
         )}] ${applicantDataFinder(data, "name")}`}</Txt>
       </div>
-      <ApplicantInterviewerScore postId={postId}/>
+      <ApplicantInterviewerScore postId={postId} />
       <div className="flex gap-4 mb-8">
         <div className="flex gap-1">
           <Txt typography="h3" color="gray" className="font-normal">

--- a/frontend/components/applicant/applicantNode/InterviewerScore.component.tsx
+++ b/frontend/components/applicant/applicantNode/InterviewerScore.component.tsx
@@ -77,7 +77,7 @@ const ApplicantInterviewerScore: FC<ApplicantInterviewerScoreProps> = ({
       {!isShow ? (
         <button
           onClick={onClick}
-          className="text-[#666666] text-sm my-4 underline-offset-2 underline"
+          className="text-secondary-200 text-sm my-4 underline-offset-2 underline"
         >
           면접관 점수 입력
         </button>
@@ -86,7 +86,7 @@ const ApplicantInterviewerScore: FC<ApplicantInterviewerScoreProps> = ({
           <div className="flex w-full justify-between items-start">
             <button
               onClick={onClick}
-              className="text-[#666666] text-sm my-4 underline-offset-2 underline"
+              className="text-secondary-200 text-sm my-4 underline-offset-2 underline"
             >
               면접관 점수 입력
             </button>

--- a/frontend/components/applicant/applicantNode/InterviewerScore.component.tsx
+++ b/frontend/components/applicant/applicantNode/InterviewerScore.component.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { getScore, postScore } from "@/src/apis/score";
-import { INTERVIEW_SCORE_KEYWOARD, ScoreKeyword } from "@/src/constants/applicant/26";
+import {
+  INTERVIEW_SCORE_KEYWOARD,
+  ScoreKeyword,
+} from "@/src/constants/applicant/26";
 import { replacer } from "@/src/functions/replacer";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import Image from "next/image";
@@ -11,43 +14,45 @@ interface ApplicantInterviewerScoreProps {
   postId: string;
 }
 
-const ApplicantInterviewerScore:FC<ApplicantInterviewerScoreProps> = ({postId}) => {
+const ApplicantInterviewerScore: FC<ApplicantInterviewerScoreProps> = ({
+  postId,
+}) => {
   const [isShow, setIsShow] = useState(false);
   const [scores, setScores] = useState<Scores>({
-    "실천력": "",
-    "협업": "",
-    "동아리애착": "",
-    "기타": "",
+    실천력: "",
+    협업: "",
+    동아리애착: "",
+    기타: "",
   });
 
-  type Scores =  {
+  type Scores = {
     [key in ScoreKeyword]: string;
   };
 
-  const onInput = (e: React.FormEvent<HTMLInputElement>, title:string) => {
+  const onInput = (e: React.FormEvent<HTMLInputElement>, title: string) => {
     const value = replacer(e.currentTarget.value, "scoreNumber");
     console.log(value);
-    setScores(scores => ({
+    setScores((scores) => ({
       ...scores,
-      [title]: value
-    }))
-  }
+      [title]: value,
+    }));
+  };
 
   const onClick = () => {
     setIsShow((prev) => !prev);
-  }
+  };
 
   const submitScore = () => {
     const request = {
       applicantId: postId,
       scoreVo: Object.entries(scores).map(([key, value]) => ({
         creteria: key as ScoreKeyword,
-        score: Number(value)
-      }))
-    }
-    mutate(request)
+        score: Number(value),
+      })),
+    };
+    mutate(request);
     setIsShow((prev) => !prev);
-  }
+  };
 
   const { data } = useQuery(["score"], () => getScore(postId), {
     onSuccess: (data) => {
@@ -57,7 +62,6 @@ const ApplicantInterviewerScore:FC<ApplicantInterviewerScoreProps> = ({postId}) 
       console.log(error);
     },
   });
-  
 
   const { mutate } = useMutation(postScore, {
     onSuccess: (data) => {
@@ -87,19 +91,23 @@ const ApplicantInterviewerScore:FC<ApplicantInterviewerScoreProps> = ({postId}) 
               면접관 점수 입력
             </button>
             <button className="h-6 w-6 opacity-90 my-3" onClick={submitScore}>
-                <Image
-                  src={
-                    require("/public/icons/arrow.forward.circle.fill.svg")
-                      .default
-                  }
-                  alt="interview score append"
-                />
+              <Image
+                src={
+                  require("/public/icons/arrow.forward.circle.fill.svg").default
+                }
+                alt="interview score append"
+              />
             </button>
           </div>
-          <div className="flex justify-between text-sm text-[#4F4F4F] mb-12 mt-4 px-4">
+          <div className="flex justify-between text-sm text-dark mb-12 mt-4 px-4">
             {INTERVIEW_SCORE_KEYWOARD.map((keyword) => (
               <div key={keyword.name} className="flex flex-col items-center">
-                <input placeholder="-" className="placeholder-gray-500 border-none text-2xl outline-none w-4 " value={scores[keyword.title]} onInput={(e) => onInput(e, keyword.title)}/>
+                <input
+                  placeholder="-"
+                  className="placeholder-gray-500 border-none text-2xl outline-none w-4 "
+                  value={scores[keyword.title]}
+                  onInput={(e) => onInput(e, keyword.title)}
+                />
                 <div>{keyword.title}</div>
               </div>
             ))}

--- a/frontend/components/applicant/applicantNode/Label.component.tsx
+++ b/frontend/components/applicant/applicantNode/Label.component.tsx
@@ -70,7 +70,7 @@ const ApplicantLabel: FC<ApplicantLabelProps> = ({ postId, generation }) => {
         <button
           onClick={toggleOpen}
           className={classNames(
-            "text-[#2160FF] bg-[#E8EFFF] translate-y-[2px] h-8 w-8 rounded-full flex items-center justify-center transition-all",
+            "text-primary bg-[#E8EFFF] translate-y-[2px] h-8 w-8 rounded-full flex items-center justify-center transition-all",
             { "rotate-45 ": openAdditional }
           )}
         >
@@ -113,7 +113,7 @@ const ApplicantLabelButton: FC<ApplicantLabelButtonProps> = ({
       className={classNames(
         "py-1 px-4 rounded-full w-max",
         label.active
-          ? "text-[#2160FF] bg-[#E8EFFF]"
+          ? "text-primary bg-[#E8EFFF]"
           : "text-[#777777] bg-[#EFEFEF]"
       )}
       onClick={onLabelClick}

--- a/frontend/components/applicant/applicantNode/Label.component.tsx
+++ b/frontend/components/applicant/applicantNode/Label.component.tsx
@@ -112,9 +112,7 @@ const ApplicantLabelButton: FC<ApplicantLabelButtonProps> = ({
       key={label.name}
       className={classNames(
         "py-1 px-4 rounded-full w-max",
-        label.active
-          ? "text-primary bg-[#E8EFFF]"
-          : "text-[#777777] bg-[#EFEFEF]"
+        label.active ? "text-primary bg-[#E8EFFF]" : "text-[#777777] bg-light"
       )}
       onClick={onLabelClick}
     >

--- a/frontend/components/applicant/applicantNode/Label.component.tsx
+++ b/frontend/components/applicant/applicantNode/Label.component.tsx
@@ -112,7 +112,9 @@ const ApplicantLabelButton: FC<ApplicantLabelButtonProps> = ({
       key={label.name}
       className={classNames(
         "py-1 px-4 rounded-full w-max",
-        label.active ? "text-primary bg-[#E8EFFF]" : "text-[#777777] bg-light"
+        label.active
+          ? "text-primary bg-[#E8EFFF]"
+          : "text-secondary-200 bg-light"
       )}
       onClick={onLabelClick}
     >

--- a/frontend/components/applicant/applicantNode/Label.component.tsx
+++ b/frontend/components/applicant/applicantNode/Label.component.tsx
@@ -70,7 +70,7 @@ const ApplicantLabel: FC<ApplicantLabelProps> = ({ postId, generation }) => {
         <button
           onClick={toggleOpen}
           className={classNames(
-            "text-primary bg-[#E8EFFF] translate-y-[2px] h-8 w-8 rounded-full flex items-center justify-center transition-all",
+            "text-primary bg-primary-200 translate-y-[2px] h-8 w-8 rounded-full flex items-center justify-center transition-all",
             { "rotate-45 ": openAdditional }
           )}
         >
@@ -113,7 +113,7 @@ const ApplicantLabelButton: FC<ApplicantLabelButtonProps> = ({
       className={classNames(
         "py-1 px-4 rounded-full w-max",
         label.active
-          ? "text-primary bg-[#E8EFFF]"
+          ? "text-primary bg-primary-200"
           : "text-secondary-200 bg-light"
       )}
       onClick={onLabelClick}

--- a/frontend/components/applicant/applicantNode/Timeline.component.tsx
+++ b/frontend/components/applicant/applicantNode/Timeline.component.tsx
@@ -76,7 +76,7 @@ const ApplicantTimelineNode: FC<ApplicantTimelineNodeProps> = ({ postId }) => {
                         "h-8 block",
                         timeline.includes(index + startIndex * seperate)
                           ? "bg-primary"
-                          : "bg-[#EFEFEF]"
+                          : "bg-light"
                       )}
                     ></div>
                   )}

--- a/frontend/components/applicant/applicantNode/Timeline.component.tsx
+++ b/frontend/components/applicant/applicantNode/Timeline.component.tsx
@@ -75,7 +75,7 @@ const ApplicantTimelineNode: FC<ApplicantTimelineNodeProps> = ({ postId }) => {
                       className={classNames(
                         "h-8 block",
                         timeline.includes(index + startIndex * seperate)
-                          ? "bg-[#2160FF]"
+                          ? "bg-primary"
                           : "bg-[#EFEFEF]"
                       )}
                     ></div>

--- a/frontend/components/applicant/applicantNode/comment/CommentDetail.component.tsx
+++ b/frontend/components/applicant/applicantNode/comment/CommentDetail.component.tsx
@@ -69,7 +69,7 @@ const ApplicantCommentDetail: FC<ApplicantCommentDetailProps> = ({
   );
 
   return (
-    <div className="border-l-4 border-[#717171] pl-3">
+    <div className="border-l-4 border-secondary-200 pl-3">
       <div className="flex justify-between mb-4">
         <div className="flex gap-4 items-end">
           <div>{comment.interviewerName}</div>
@@ -86,7 +86,9 @@ const ApplicantCommentDetail: FC<ApplicantCommentDetailProps> = ({
             }
             alt="smile face"
           />
-          <span className="text-xs text-[#808080]">{comment.likeCount}</span>
+          <span className="text-xs text-secondary-200">
+            {comment.likeCount}
+          </span>
         </button>
       </div>
       <ApplicantCommentEditorOrViewer
@@ -96,9 +98,9 @@ const ApplicantCommentDetail: FC<ApplicantCommentDetailProps> = ({
         setIsEdit={setIsEdit}
       />
       {comment.canEdit && (
-        <div className="flex text-sm gap-2 text-[#666666] items-center">
+        <div className="flex text-sm gap-2 text-secondary-200 items-center">
           <button onClick={() => setIsEdit((prev) => !prev)}>수정</button>
-          <div className="border-x-[0.5px] h-4 !w-0 border-[#666666]"></div>
+          <div className="border-x-[0.5px] h-4 !w-0 border-secondary-200"></div>
           <CommentDeleteButton
             commentId={comment.id}
             cardId={cardId}

--- a/frontend/components/applicant/applicantNode/comment/EditorOrViewer.component.tsx
+++ b/frontend/components/applicant/applicantNode/comment/EditorOrViewer.component.tsx
@@ -49,7 +49,7 @@ const ApplicantCommentEditorOrViewer: FC<
         <>
           <div className="my-4">
             <Editor
-              className="w-full my-4 border-[1px] rounded border-[#DBDBDB] p-3 text-sm"
+              className="w-full my-4 border-[1px] rounded border-secondary-100 p-3 text-sm"
               height="6rem"
               initialEditType="markdown"
               usageStatistics={false}

--- a/frontend/components/applicant/applicantNode/comment/InputForm.component.tsx
+++ b/frontend/components/applicant/applicantNode/comment/InputForm.component.tsx
@@ -119,7 +119,7 @@ const ApplicantCommentInputForm: FC<ApplicantCommentInputFormProps> = ({
       </div>
       <div className="py-4">
         <Editor
-          className="w-full my-4 border-[1px] rounded border-[#DBDBDB] p-3 text-sm"
+          className="w-full my-4 border-[1px] rounded border-secondary-100 p-3 text-sm"
           height="6rem"
           initialEditType="markdown"
           usageStatistics={false}

--- a/frontend/components/application/applicationLayout/timeline/TimelineRow.component.tsx
+++ b/frontend/components/application/applicationLayout/timeline/TimelineRow.component.tsx
@@ -53,7 +53,7 @@ const TimelineRow: FC<TimelineRowProps> = ({ date, isLast, index }) => {
           />
           <label
             htmlFor={date.getTime().toString()}
-            className="h-8 block peer-checked:bg-primary bg-[#EFEFEF]"
+            className="h-8 block peer-checked:bg-primary bg-light"
           ></label>
         </>
       )}

--- a/frontend/components/application/applicationLayout/timeline/TimelineRow.component.tsx
+++ b/frontend/components/application/applicationLayout/timeline/TimelineRow.component.tsx
@@ -53,7 +53,7 @@ const TimelineRow: FC<TimelineRowProps> = ({ date, isLast, index }) => {
           />
           <label
             htmlFor={date.getTime().toString()}
-            className="h-8 block peer-checked:bg-[#2160FF] bg-[#EFEFEF]"
+            className="h-8 block peer-checked:bg-primary bg-[#EFEFEF]"
           ></label>
         </>
       )}

--- a/frontend/components/application/applicationNode/NextButton.component.tsx
+++ b/frontend/components/application/applicationNode/NextButton.component.tsx
@@ -91,7 +91,7 @@ const ApplicationNextButton: FC<ApplicationNextButtonProps> = ({
   return (
     <div className="flex gap-2 my-4">
       <button
-        className="flex-1 rounded-md flex justify-center items-center p-4 bg-[#EFEFEF]"
+        className="flex-1 rounded-md flex justify-center items-center p-4 bg-light"
         onClick={goPrevIndex}
       >
         이전
@@ -111,7 +111,7 @@ const ApplicationNextButton: FC<ApplicationNextButtonProps> = ({
         className={
           canNext
             ? nextButtonClassName + " bg-dark text-white"
-            : nextButtonClassName + " bg-[#EFEFEF] text-[#C8C8C8]"
+            : nextButtonClassName + " bg-light text-[#C8C8C8]"
         }
       >
         {isLast

--- a/frontend/components/application/applicationNode/NextButton.component.tsx
+++ b/frontend/components/application/applicationNode/NextButton.component.tsx
@@ -110,7 +110,7 @@ const ApplicationNextButton: FC<ApplicationNextButtonProps> = ({
         disabled={!canNext}
         className={
           canNext
-            ? nextButtonClassName + " bg-[#303030] text-white"
+            ? nextButtonClassName + " bg-dark text-white"
             : nextButtonClassName + " bg-[#EFEFEF] text-[#C8C8C8]"
         }
       >

--- a/frontend/components/application/applicationNode/NextButton.component.tsx
+++ b/frontend/components/application/applicationNode/NextButton.component.tsx
@@ -111,7 +111,7 @@ const ApplicationNextButton: FC<ApplicationNextButtonProps> = ({
         className={
           canNext
             ? nextButtonClassName + " bg-dark text-white"
-            : nextButtonClassName + " bg-light text-[#C8C8C8]"
+            : nextButtonClassName + " bg-light text-secondary-100"
         }
       >
         {isLast

--- a/frontend/components/application/applicationNode/Text.component.tsx
+++ b/frontend/components/application/applicationNode/Text.component.tsx
@@ -34,7 +34,7 @@ const ApplicationText: FC<ApplicationTextProps> = ({ data }) => {
       <input
         className={classNames(
           "my-2 border rounded-lg p-4 w-full",
-          isError && "border-[#DC0000]"
+          isError && "border-error"
         )}
         type="text"
         id={id}
@@ -54,7 +54,7 @@ const ApplicationText: FC<ApplicationTextProps> = ({ data }) => {
       />
       {isError && textData.errorMessages ? (
         <div className="absolute w-full translate-x-[100%]">
-          <div className="w-fit text-[#DC0000] -translate-x-[calc(100%+1rem)] -translate-y-12">
+          <div className="w-fit text-error -translate-x-[calc(100%+1rem)] -translate-y-12">
             {textData.errorMessages}
           </div>
         </div>

--- a/frontend/components/common/Checkbox.component.tsx
+++ b/frontend/components/common/Checkbox.component.tsx
@@ -36,7 +36,7 @@ export const Checkbox: FC<CheckboxProps> = ({
         className={classNames(
           "flex items-center justify-center w-full py-4 border rounded-md cursor-pointer",
           checked
-            ? "bg-[#303030] text-white border-black"
+            ? "bg-dark text-white border-black"
             : "border-gray-300 text-black bg-white",
           disabled && "bg-gray-200 text-gray-400 cursor-not-allowed"
         )}

--- a/frontend/components/common/LabeledInput.component.tsx
+++ b/frontend/components/common/LabeledInput.component.tsx
@@ -8,7 +8,7 @@ type LabeledInputProps = {
 
 const LabeledInput = ({ label, ...props }: LabeledInputProps) => (
   <div className="flex flex-col w-full gap-1 mt-8">
-    <label htmlFor={props.id} className="text-sm text-[#3c3c3c]">
+    <label htmlFor={props.id} className="text-sm text-dark">
       {label}
     </label>
     <input

--- a/frontend/components/common/LabeledTextarea.tsx
+++ b/frontend/components/common/LabeledTextarea.tsx
@@ -9,7 +9,7 @@ type LabeledTextareaProps = {
 const LabeledTextarea = ({ label, ...props }: LabeledTextareaProps) => {
   return (
     <div className="flex flex-col w-full gap-1 mt-8">
-      <label htmlFor={props.id} className="text-sm text-[#3c3c3c]">
+      <label htmlFor={props.id} className="text-sm text-dark">
         {label}
       </label>
       <textarea

--- a/frontend/components/common/PageNavbar.component.tsx
+++ b/frontend/components/common/PageNavbar.component.tsx
@@ -13,7 +13,7 @@ const PageNavbarComponent = ({
         <a
           key={i}
           href={url + `&page=${i + 1}`}
-          className={i + 1 === page ? "p-3" : "text-[#B6B6B6] p-3"}
+          className={i + 1 === page ? "p-3" : "text-secondary-100 p-3"}
         >
           {i + 1}
         </a>

--- a/frontend/components/common/Radio.component.tsx
+++ b/frontend/components/common/Radio.component.tsx
@@ -30,7 +30,7 @@ const Radio: FC<RadioProps> = ({
         className={classNames(
           "flex items-center justify-center w-full py-4 border rounded-md cursor-pointer",
           isCheck
-            ? "bg-[#303030] text-white border-black"
+            ? "bg-dark text-white border-black"
             : "border-gray-300 text-black bg-white",
           disabled && "bg-gray-200 text-gray-400 cursor-not-allowed"
         )}

--- a/frontend/components/common/SortList.component.tsx
+++ b/frontend/components/common/SortList.component.tsx
@@ -54,7 +54,7 @@ const SortListComponent = ({ sortList, selected }: SortListComponent) => {
               }}
               className={classNames(
                 "flex justify-end py-2 px-6 capitalize cursor-pointer",
-                { "text-[#9A9A9A] cursor-auto": sort.type === selected }
+                { "text-secondary-200 cursor-auto": sort.type === selected }
               )}
             >
               {sort.type}

--- a/frontend/components/common/SortList.component.tsx
+++ b/frontend/components/common/SortList.component.tsx
@@ -31,7 +31,7 @@ const SortListComponent = ({ sortList, selected }: SortListComponent) => {
   return (
     <div className="relative">
       <button
-        className="flex items-center bg-[#F9FBFF] p-4 gap-2 rounded-2xl text-secondary-200 z-20"
+        className="flex items-center bg-primary-100 p-4 gap-2 rounded-2xl text-secondary-200 z-20"
         onClick={(e) => {
           e.preventDefault();
           setIsOpen((prev) => !prev);

--- a/frontend/components/common/SortList.component.tsx
+++ b/frontend/components/common/SortList.component.tsx
@@ -31,7 +31,7 @@ const SortListComponent = ({ sortList, selected }: SortListComponent) => {
   return (
     <div className="relative">
       <button
-        className="flex items-center bg-[#F9FBFF] p-4 gap-2 rounded-2xl text-[#7E7E7E] z-20"
+        className="flex items-center bg-[#F9FBFF] p-4 gap-2 rounded-2xl text-secondary-200 z-20"
         onClick={(e) => {
           e.preventDefault();
           setIsOpen((prev) => !prev);

--- a/frontend/components/common/SortList.component.tsx
+++ b/frontend/components/common/SortList.component.tsx
@@ -38,11 +38,11 @@ const SortListComponent = ({ sortList, selected }: SortListComponent) => {
         }}
       >
         Sort by :
-        <span className="font-semibold capitalize text-[#3D3C42]">{order}</span>
+        <span className="font-semibold capitalize text-dark">{order}</span>
         <img src="/icons/chevron-down.svg" alt="drop_down"></img>
       </button>
       {isOpen ? (
-        <div className="flex flex-col absolute w-full border-[#F0F0F0] rounded-xl border-[1px] bg-white p-6 font-semibold -mt-4 text-[#3D3C42]">
+        <div className="flex flex-col absolute w-full border-[#F0F0F0] rounded-xl border-[1px] bg-white p-6 font-semibold -mt-4 text-dark">
           {sortList.map((sort) => (
             <button
               key={sort.type}

--- a/frontend/components/common/SortList.component.tsx
+++ b/frontend/components/common/SortList.component.tsx
@@ -42,7 +42,7 @@ const SortListComponent = ({ sortList, selected }: SortListComponent) => {
         <img src="/icons/chevron-down.svg" alt="drop_down"></img>
       </button>
       {isOpen ? (
-        <div className="flex flex-col absolute w-full border-[#F0F0F0] rounded-xl border-[1px] bg-white p-6 font-semibold -mt-4 text-dark">
+        <div className="flex flex-col absolute w-full border-light rounded-xl border-[1px] bg-white p-6 font-semibold -mt-4 text-dark">
           {sortList.map((sort) => (
             <button
               key={sort.type}

--- a/frontend/components/common/Txt.component.tsx
+++ b/frontend/components/common/Txt.component.tsx
@@ -14,10 +14,10 @@ const typographyType = {
 
 const colorType = {
   black: "text-black",
-  gray: "text-[#666]",
+  gray: "text-secondary-200",
   white: "text-white",
   blue: "text-primary",
-  light_gray: "text-[#8C8C8C]",
+  light_gray: "text-secondary-200",
 };
 
 interface TxtProps {

--- a/frontend/components/common/Txt.component.tsx
+++ b/frontend/components/common/Txt.component.tsx
@@ -16,7 +16,7 @@ const colorType = {
   black: "text-black",
   gray: "text-[#666]",
   white: "text-white",
-  blue: "text-[#2160FF]",
+  blue: "text-primary",
   light_gray: "text-[#8C8C8C]",
 };
 

--- a/frontend/components/common/navbar/Button.component.tsx
+++ b/frontend/components/common/navbar/Button.component.tsx
@@ -24,7 +24,7 @@ const NavbarButtonComponent = ({ value }: NavbarButtonComponent) => {
     <button
       className={
         findmenuIndex.toString() === navbarId
-          ? `bg-[#303030] text-white${buttonClassName}`
+          ? `bg-dark text-white${buttonClassName}`
           : `bg-white text-gray-400${buttonClassName}`
       }
       onClick={onClick}

--- a/frontend/components/common/navbar/NavbarCell.component.tsx
+++ b/frontend/components/common/navbar/NavbarCell.component.tsx
@@ -20,7 +20,7 @@ const CommonNavbarCellComponent = ({
   isShort,
 }: CommonNavbarCellComponent) => {
   const linkButtonClassName =
-    "flex justify-between p-4 hover:bg-[#B9B9B9] hover:text-white rounded-lg";
+    "flex justify-between p-4 hover:bg-secondary-100 hover:text-white rounded-lg";
   return (
     <a
       className={

--- a/frontend/components/common/navbar/UserInfo.component.tsx
+++ b/frontend/components/common/navbar/UserInfo.component.tsx
@@ -29,7 +29,7 @@ const NavbarUserInfo = () => {
         <Txt className="font-medium">{data.name}</Txt>
       </div>
       <div>
-        <Txt className="text-[#757575]">
+        <Txt className="text-secondary-200">
           {`${data.year}기 | ${roleTranslater(data.role)}`}{" "}
         </Txt>
       </div>

--- a/frontend/components/interview/List.component.tsx
+++ b/frontend/components/interview/List.component.tsx
@@ -16,7 +16,7 @@ const InterviewListComponent = () => {
     <div className="flex flex-col">
       {boardData.map((board, idx) => (
         <button
-          className="flex h-[calc(14vh-6.5rem)] min-h-[4.5rem] border-t-[1px] border-[#B9B9B9]"
+          className="flex h-[calc(14vh-6.5rem)] min-h-[4.5rem] border-t-[1px] border-secondary-100"
           onClick={onBoardClick}
           key={idx}
         >

--- a/frontend/components/interview/List.component.tsx
+++ b/frontend/components/interview/List.component.tsx
@@ -22,7 +22,7 @@ const InterviewListComponent = () => {
         >
           <div className="flex w-full h-full items-center justify-between">
             <div className="font-semibold text-lg">{board.title}</div>
-            <div className="flex gap-24 text-[#8C8C8C]">
+            <div className="flex gap-24 text-secondary-200">
               <div className="flex gap-12">
                 {board.apply.map((a) => (
                   <div key={a}>{a}</div>

--- a/frontend/components/interview/Search.component.tsx
+++ b/frontend/components/interview/Search.component.tsx
@@ -1,6 +1,6 @@
 const InterviewSearchComponent = () => {
   return (
-    <form className="flex items-center py-2 px-4 bg-[#F9FBFF] rounded-2xl gap-2">
+    <form className="flex items-center py-2 px-4 bg-primary-100 rounded-2xl gap-2">
       <button>
         <img src="/icons/search-icon.svg" alt="search" />
       </button>

--- a/frontend/components/interview/Search.component.tsx
+++ b/frontend/components/interview/Search.component.tsx
@@ -5,7 +5,7 @@ const InterviewSearchComponent = () => {
         <img src="/icons/search-icon.svg" alt="search" />
       </button>
       <input
-        className="p-2 color-[#B5B7C0] bg-transparent outline-none"
+        className="p-2 color-secondary-100 bg-transparent outline-none"
         type="text"
         placeholder="search"
       ></input>

--- a/frontend/components/interview/modal/AvgScore.component.tsx
+++ b/frontend/components/interview/modal/AvgScore.component.tsx
@@ -14,7 +14,7 @@ const InterviewAvgScoreComponent: FC<InterviewAvgScoreProps> = ({
   return (
     <div className="flex w-full items-center mt-10 gap-9">
       <div className="flex-[0_0_6.7rem]">
-        <span className="text-5xl font-extrabold text-[#333333] relative">
+        <span className="text-5xl font-extrabold text-dark relative">
           <div className="absolute w-full h-5 bg-[#A6BFFF] top-9 -z-10"></div>
           {clamp(totalAverage, 0, 5).toFixed(2)}
         </span>
@@ -25,10 +25,10 @@ const InterviewAvgScoreComponent: FC<InterviewAvgScoreProps> = ({
             key={score.creteria}
             className="flex flex-col items-center justify-center gap-1 flex-[0_0_4.1rem]"
           >
-            <span className="text-2xl font-semibold text-[#4E4E4E] max-w-full">
+            <span className="text-2xl font-semibold text-dark max-w-full">
               {clamp(score.score, 0, 5).toFixed(2)}
             </span>
-            <span className="text-sm text-[#4F4F4F]">{score.creteria}</span>
+            <span className="text-sm text-dark">{score.creteria}</span>
           </div>
         ))}
       </div>

--- a/frontend/components/interview/modal/AvgScore.component.tsx
+++ b/frontend/components/interview/modal/AvgScore.component.tsx
@@ -15,7 +15,7 @@ const InterviewAvgScoreComponent: FC<InterviewAvgScoreProps> = ({
     <div className="flex w-full items-center mt-10 gap-9">
       <div className="flex-[0_0_6.7rem]">
         <span className="text-5xl font-extrabold text-dark relative">
-          <div className="absolute w-full h-5 bg-[#A6BFFF] top-9 -z-10"></div>
+          <div className="absolute w-full h-5 bg-primary-300 top-9 -z-10"></div>
           {clamp(totalAverage, 0, 5).toFixed(2)}
         </span>
       </div>

--- a/frontend/components/interview/modal/Edit.component.tsx
+++ b/frontend/components/interview/modal/Edit.component.tsx
@@ -98,7 +98,7 @@ const InterviewEditComponent = ({ data }: InterviewEditComponentProps) => {
               취소
             </button>
             <button
-              className="flex-1 rounded-md flex justify-center items-center p-3 bg-[#303030] text-white"
+              className="flex-1 rounded-md flex justify-center items-center p-3 bg-dark text-white"
               onClick={handleUpload}
             >
               수정하기

--- a/frontend/components/interview/modal/Edit.component.tsx
+++ b/frontend/components/interview/modal/Edit.component.tsx
@@ -53,7 +53,7 @@ const InterviewEditComponent = ({ data }: InterviewEditComponentProps) => {
   return (
     <div className="flex flex-col w-full my-10 items-end">
       <button onClick={() => setIsOpen((prev) => !prev)}>
-        <span className="text-sm text-[#A7A7A7] underline underline-offset-2">
+        <span className="text-sm text-secondary-100 underline underline-offset-2">
           {isOpen ? "접어 두기" : "면접기록 수정하기"}
         </span>
       </button>

--- a/frontend/components/interview/modal/Edit.component.tsx
+++ b/frontend/components/interview/modal/Edit.component.tsx
@@ -85,7 +85,7 @@ const InterviewEditComponent = ({ data }: InterviewEditComponentProps) => {
           />
           <div className="flex gap-2 mt-4">
             <button
-              className="flex-1 rounded-md flex justify-center items-center p-3 bg-[#EFEFEF]"
+              className="flex-1 rounded-md flex justify-center items-center p-3 bg-light"
               onClick={() => {
                 setIsOpen(false);
                 setInterviewData({

--- a/frontend/components/interview/modal/Score.component.tsx
+++ b/frontend/components/interview/modal/Score.component.tsx
@@ -14,7 +14,7 @@ const InterviewScoreComponent: FC<InterviewScoreProps> = ({ score }) => {
   return (
     <div className="flex flex-col w-full my-10 items-end">
       <button onClick={() => setIsOpen((prev) => !prev)}>
-        <span className="text-sm text-[#A7A7A7] underline underline-offset-2">
+        <span className="text-sm text-secondary-100 underline underline-offset-2">
           {isOpen ? "접어 두기" : "상세 보기"}
         </span>
       </button>

--- a/frontend/components/interview/modal/ScoreCell.component.tsx
+++ b/frontend/components/interview/modal/ScoreCell.component.tsx
@@ -8,7 +8,7 @@ const InterviewScoreCellComponent = ({ item }: InterviewScoreCellComponent) => {
   return (
     <div className="flex items-center gap-9">
       <div className="flex flex-[0_0_6.7rem] justify-center items-center">
-        <div className="text-primary bg-[#E8EFFF] px-5 py-2 rounded-3xl w-full">
+        <div className="text-primary bg-primary-200 px-5 py-2 rounded-3xl w-full">
           {item[0]}
         </div>
       </div>

--- a/frontend/components/interview/modal/ScoreCell.component.tsx
+++ b/frontend/components/interview/modal/ScoreCell.component.tsx
@@ -8,7 +8,7 @@ const InterviewScoreCellComponent = ({ item }: InterviewScoreCellComponent) => {
   return (
     <div className="flex items-center gap-9">
       <div className="flex flex-[0_0_6.7rem] justify-center items-center">
-        <div className="text-[#2160FF] bg-[#E8EFFF] px-5 py-2 rounded-3xl w-full">
+        <div className="text-primary bg-[#E8EFFF] px-5 py-2 rounded-3xl w-full">
           {item[0]}
         </div>
       </div>

--- a/frontend/components/interview/modal/Upload.component.tsx
+++ b/frontend/components/interview/modal/Upload.component.tsx
@@ -28,7 +28,7 @@ const InterviewUploadComponent = () => {
   return (
     <div className="flex flex-col w-full my-10 items-end">
       <button onClick={() => setIsOpen((prev) => !prev)}>
-        <span className="text-sm text-[#A7A7A7] underline underline-offset-2">
+        <span className="text-sm text-secondary-100 underline underline-offset-2">
           {isOpen ? "접어 두기" : "면접기록 입력하기"}
         </span>
       </button>

--- a/frontend/components/interview/modal/Upload.component.tsx
+++ b/frontend/components/interview/modal/Upload.component.tsx
@@ -60,7 +60,7 @@ const InterviewUploadComponent = () => {
           />
           <div className="flex gap-2 mt-4">
             <button
-              className="flex-1 rounded-md flex justify-center items-center p-3 bg-[#EFEFEF]"
+              className="flex-1 rounded-md flex justify-center items-center p-3 bg-light"
               onClick={() => {
                 setIsOpen(false);
                 setInterviewData({

--- a/frontend/components/interview/modal/Upload.component.tsx
+++ b/frontend/components/interview/modal/Upload.component.tsx
@@ -73,7 +73,7 @@ const InterviewUploadComponent = () => {
               취소
             </button>
             <button
-              className="flex-1 rounded-md flex justify-center items-center p-3 bg-[#303030] text-white"
+              className="flex-1 rounded-md flex justify-center items-center p-3 bg-dark text-white"
               onClick={() => {
                 setIsOpen(false);
                 interviewUpload(interviewData);

--- a/frontend/components/kanban/card/AddCard.component.tsx
+++ b/frontend/components/kanban/card/AddCard.component.tsx
@@ -56,7 +56,7 @@ function KanbanAddCardComponent({ columnId }: KanbanAddCardComponent) {
       ) : (
         <button
           type="button"
-          className="flex gap-2 justify-center items-center text-[#828282]"
+          className="flex gap-2 justify-center items-center text-secondary-200"
           onClick={() => {
             setIsOpenAddCard(true);
           }}

--- a/frontend/components/kanban/card/AddCard.component.tsx
+++ b/frontend/components/kanban/card/AddCard.component.tsx
@@ -34,12 +34,12 @@ function KanbanAddCardComponent({ columnId }: KanbanAddCardComponent) {
     <div className="mt-2">
       {isOpenAddCard ? (
         <form
-          className="w-[17rem] border-[1px] border-[#F0F0F0] p-3 rounded-lg"
+          className="w-[17rem] border-[1px] border-light p-3 rounded-lg"
           onSubmit={(e) => addCardSubmit(e)}
         >
           <input
             type="text"
-            className="p-3 border-[1px] border-[#F0F0F0] drop-shadow-md bg-white rounded-lg w-full text-sm my-3 outline-none"
+            className="p-3 border-[1px] border-light drop-shadow-md bg-white rounded-lg w-full text-sm my-3 outline-none"
             placeholder="Enter a title for this card"
             value={title}
             onChange={(e) => setTitle(e.target.value)}

--- a/frontend/components/kanban/card/Card.component.tsx
+++ b/frontend/components/kanban/card/Card.component.tsx
@@ -51,9 +51,9 @@ function KanbanCardComponent({
       )}
       onClick={onClickDetail}
     >
-      <div className="text-xs text-[#666666]">{major}</div>
+      <div className="text-xs text-secondary-200">{major}</div>
       <div className="font-bold truncate">{title}</div>
-      <div className="mt-2 flex justify-between items-center text-sm text-[#666666]">
+      <div className="mt-2 flex justify-between items-center text-sm text-secondary-200">
         <div className="text-sm">{apply.join(" / ")}</div>
         <div className="flex gap-3">
           <div className="flex">

--- a/frontend/components/kanban/card/Card.component.tsx
+++ b/frontend/components/kanban/card/Card.component.tsx
@@ -43,7 +43,7 @@ function KanbanCardComponent({
   return (
     <div
       className={classNames(
-        "border-[1px] w-[14.9rem] p-3 rounded-lg drop-shadow-md bg-white hover:border-[#7AA0FF]",
+        "border-[1px] w-[14.9rem] p-3 rounded-lg drop-shadow-md bg-white hover:border-primary-400",
         (applicantId !== "" && dataApplicantId == applicantId) ||
           `${id}` == cardId
           ? "border-primary"

--- a/frontend/components/kanban/card/Card.component.tsx
+++ b/frontend/components/kanban/card/Card.component.tsx
@@ -46,7 +46,7 @@ function KanbanCardComponent({
         "border-[1px] w-[14.9rem] p-3 rounded-lg drop-shadow-md bg-white hover:border-[#7AA0FF]",
         (applicantId !== "" && dataApplicantId == applicantId) ||
           `${id}` == cardId
-          ? "border-[#2160FF]"
+          ? "border-primary"
           : "border-[#F0F0F0]"
       )}
       onClick={onClickDetail}

--- a/frontend/components/kanban/card/Card.component.tsx
+++ b/frontend/components/kanban/card/Card.component.tsx
@@ -47,7 +47,7 @@ function KanbanCardComponent({
         (applicantId !== "" && dataApplicantId == applicantId) ||
           `${id}` == cardId
           ? "border-primary"
-          : "border-[#F0F0F0]"
+          : "border-light"
       )}
       onClick={onClickDetail}
     >

--- a/frontend/components/kanban/column/AddColumn.component.tsx
+++ b/frontend/components/kanban/column/AddColumn.component.tsx
@@ -30,12 +30,12 @@ function KanbanAddColumnComponent() {
     <div className="w-[17rem]">
       {isOpenAddColumn ? (
         <form
-          className="w-[17rem] border-[1px] border-[#F0F0F0] p-3 rounded-lg"
+          className="w-[17rem] border-[1px] border-light p-3 rounded-lg"
           onSubmit={(e) => addColumnSubmit(e)}
         >
           <input
             type="text"
-            className="p-3 border-[1px] border-[#F0F0F0] bg-white rounded-lg w-full text-sm my-3 outline-none"
+            className="p-3 border-[1px] border-light bg-white rounded-lg w-full text-sm my-3 outline-none"
             placeholder="Enter list title"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
@@ -52,7 +52,7 @@ function KanbanAddColumnComponent() {
       ) : (
         <button
           type="button"
-          className="w-[17rem] flex gap-6 justify-start items-center text-[#828282] py-4 px-6 bg-[#EFEFEF] h-fit rounded-lg text-lg"
+          className="w-[17rem] flex gap-6 justify-start items-center text-[#828282] py-4 px-6 bg-light h-fit rounded-lg text-lg"
           onClick={() => setIsOpenAddColumn(true)}
         >
           <img src="/icons/ellipsis.plus.svg" alt="AddColumn" />

--- a/frontend/components/kanban/column/AddColumn.component.tsx
+++ b/frontend/components/kanban/column/AddColumn.component.tsx
@@ -52,7 +52,7 @@ function KanbanAddColumnComponent() {
       ) : (
         <button
           type="button"
-          className="w-[17rem] flex gap-6 justify-start items-center text-[#828282] py-4 px-6 bg-light h-fit rounded-lg text-lg"
+          className="w-[17rem] flex gap-6 justify-start items-center text-secondary-200 py-4 px-6 bg-light h-fit rounded-lg text-lg"
           onClick={() => setIsOpenAddColumn(true)}
         >
           <img src="/icons/ellipsis.plus.svg" alt="AddColumn" />

--- a/frontend/components/kanban/column/Column.component.tsx
+++ b/frontend/components/kanban/column/Column.component.tsx
@@ -83,7 +83,7 @@ const KanbanColumnComponent: FC<KanbanColumnComponentProps> = ({
           <div className="flex justify-between">
             <div className="flex gap-2 items-center">
               <div className="font-bold text-lg">{title}</div>
-              <div className="flex justify-center items-center px-3 rounded-full bg-[#E8EFFF] text-xs text-primary h-4">
+              <div className="flex justify-center items-center px-3 rounded-full bg-primary-200 text-xs text-primary h-4">
                 {columnCount}
               </div>
             </div>

--- a/frontend/components/kanban/column/Column.component.tsx
+++ b/frontend/components/kanban/column/Column.component.tsx
@@ -83,7 +83,7 @@ const KanbanColumnComponent: FC<KanbanColumnComponentProps> = ({
           <div className="flex justify-between">
             <div className="flex gap-2 items-center">
               <div className="font-bold text-lg">{title}</div>
-              <div className="flex justify-center items-center px-3 rounded-full bg-[#E8EFFF] text-xs text-[#2160FF] h-4">
+              <div className="flex justify-center items-center px-3 rounded-full bg-[#E8EFFF] text-xs text-primary h-4">
                 {columnCount}
               </div>
             </div>

--- a/frontend/components/kanban/column/Column.component.tsx
+++ b/frontend/components/kanban/column/Column.component.tsx
@@ -75,7 +75,7 @@ const KanbanColumnComponent: FC<KanbanColumnComponentProps> = ({
     >
       {(provided) => (
         <div
-          className="h-fit border-[1px] border-[#F0F0F0] w-fit p-4 rounded-lg min-w-[17rem] bg-white"
+          className="h-fit border-[1px] border-light w-fit p-4 rounded-lg min-w-[17rem] bg-white"
           ref={provided.innerRef}
           {...provided.draggableProps}
           {...provided.dragHandleProps}

--- a/frontend/components/kanban/column/ColumnDetail.compontent.tsx
+++ b/frontend/components/kanban/column/ColumnDetail.compontent.tsx
@@ -7,7 +7,7 @@ const KanbanColumnDetailComponent = ({
 }: KanbanColumnDetailComponentProps) => {
   return (
     <div
-      className="flex flex-col gap-5 px-6 py-7 bg-white border-[1px] border-[#F0F0F0] justify-center items-center rounded-xl shadow-[0_2px_4px_0_rgba(0,0,0,0.11)] text-[#666] text-lg absolute -right-[3rem] top-9 z-20"
+      className="flex flex-col gap-5 px-6 py-7 bg-white border-[1px] border-light justify-center items-center rounded-xl shadow-[0_2px_4px_0_rgba(0,0,0,0.11)] text-[#666] text-lg absolute -right-[3rem] top-9 z-20"
       onMouseLeave={() => {
         setIsDetailOpen(false);
       }}

--- a/frontend/components/kanban/column/ColumnDetail.compontent.tsx
+++ b/frontend/components/kanban/column/ColumnDetail.compontent.tsx
@@ -7,7 +7,7 @@ const KanbanColumnDetailComponent = ({
 }: KanbanColumnDetailComponentProps) => {
   return (
     <div
-      className="flex flex-col gap-5 px-6 py-7 bg-white border-[1px] border-light justify-center items-center rounded-xl shadow-[0_2px_4px_0_rgba(0,0,0,0.11)] text-[#666] text-lg absolute -right-[3rem] top-9 z-20"
+      className="flex flex-col gap-5 px-6 py-7 bg-white border-[1px] border-light justify-center items-center rounded-xl shadow-[0_2px_4px_0_rgba(0,0,0,0.11)] text-secondary-200 text-lg absolute -right-[3rem] top-9 z-20"
       onMouseLeave={() => {
         setIsDetailOpen(false);
       }}

--- a/frontend/components/kanban/column/ColumnWithBackButton.component.tsx
+++ b/frontend/components/kanban/column/ColumnWithBackButton.component.tsx
@@ -53,7 +53,7 @@ const KanbanColumnDetailCard: FC<KanbanDetailCardProps> = ({
           <div className="flex justify-between">
             <div className="flex gap-2 items-center">
               <div className="font-bold text-lg">{cardTitle}</div>
-              <div className="flex justify-center items-center px-3 rounded-full bg-[#E8EFFF] text-xs text-[#2160FF] h-4">
+              <div className="flex justify-center items-center px-3 rounded-full bg-[#E8EFFF] text-xs text-primary h-4">
                 {cardCount}
               </div>
             </div>

--- a/frontend/components/kanban/column/ColumnWithBackButton.component.tsx
+++ b/frontend/components/kanban/column/ColumnWithBackButton.component.tsx
@@ -53,7 +53,7 @@ const KanbanColumnDetailCard: FC<KanbanDetailCardProps> = ({
           <div className="flex justify-between">
             <div className="flex gap-2 items-center">
               <div className="font-bold text-lg">{cardTitle}</div>
-              <div className="flex justify-center items-center px-3 rounded-full bg-[#E8EFFF] text-xs text-primary h-4">
+              <div className="flex justify-center items-center px-3 rounded-full bg-primary-200 text-xs text-primary h-4">
                 {cardCount}
               </div>
             </div>

--- a/frontend/components/kanban/column/ColumnWithBackButton.component.tsx
+++ b/frontend/components/kanban/column/ColumnWithBackButton.component.tsx
@@ -49,7 +49,7 @@ const KanbanColumnDetailCard: FC<KanbanDetailCardProps> = ({
         <KanbanDetailBackButton generation={generation} />
       </div>
       <div className="overflow-auto max-h-[calc(100vh-10em)]">
-        <div className="h-fit border-[1px] border-[#F0F0F0] w-fit p-4 rounded-lg min-w-[17rem] bg-white">
+        <div className="h-fit border-[1px] border-light w-fit p-4 rounded-lg min-w-[17rem] bg-white">
           <div className="flex justify-between">
             <div className="flex gap-2 items-center">
               <div className="font-bold text-lg">{cardTitle}</div>

--- a/frontend/components/kanban/content/work/EditorOrViewer.component.tsx
+++ b/frontend/components/kanban/content/work/EditorOrViewer.component.tsx
@@ -52,7 +52,7 @@ const WorkEditorOrViewer: FC<WorkEditorOrViewerProps> = ({
         <>
           <div className="my-4">
             <Editor
-              className="w-full my-4 border-[1px] rounded border-[#DBDBDB] p-3 text-sm"
+              className="w-full my-4 border-[1px] rounded border-secondary-100 p-3 text-sm"
               height="24rem"
               initialEditType="markdown"
               usageStatistics={false}

--- a/frontend/components/kanban/content/work/Label.component.tsx
+++ b/frontend/components/kanban/content/work/Label.component.tsx
@@ -112,9 +112,7 @@ const WorkLabelButton: FC<WorkLabelButtonProps> = ({
       key={label.name}
       className={classNames(
         "py-1 px-4 rounded-full w-max",
-        label.active
-          ? "text-primary bg-[#E8EFFF]"
-          : "text-[#777777] bg-[#EFEFEF]"
+        label.active ? "text-primary bg-[#E8EFFF]" : "text-[#777777] bg-light"
       )}
       onClick={onLabelClick}
     >

--- a/frontend/components/kanban/content/work/Label.component.tsx
+++ b/frontend/components/kanban/content/work/Label.component.tsx
@@ -70,7 +70,7 @@ const WorkLabel: FC<WorkLabelProps> = ({ cardId, generation }) => {
         <button
           onClick={toggleOpen}
           className={classNames(
-            "text-[#2160FF] bg-[#E8EFFF] translate-y-[2px] h-8 w-8 rounded-full flex items-center justify-center transition-all",
+            "text-primary bg-[#E8EFFF] translate-y-[2px] h-8 w-8 rounded-full flex items-center justify-center transition-all",
             { "rotate-45 ": openAdditional }
           )}
         >
@@ -113,7 +113,7 @@ const WorkLabelButton: FC<WorkLabelButtonProps> = ({
       className={classNames(
         "py-1 px-4 rounded-full w-max",
         label.active
-          ? "text-[#2160FF] bg-[#E8EFFF]"
+          ? "text-primary bg-[#E8EFFF]"
           : "text-[#777777] bg-[#EFEFEF]"
       )}
       onClick={onLabelClick}

--- a/frontend/components/kanban/content/work/Label.component.tsx
+++ b/frontend/components/kanban/content/work/Label.component.tsx
@@ -70,7 +70,7 @@ const WorkLabel: FC<WorkLabelProps> = ({ cardId, generation }) => {
         <button
           onClick={toggleOpen}
           className={classNames(
-            "text-primary bg-[#E8EFFF] translate-y-[2px] h-8 w-8 rounded-full flex items-center justify-center transition-all",
+            "text-primary bg-primary-200 translate-y-[2px] h-8 w-8 rounded-full flex items-center justify-center transition-all",
             { "rotate-45 ": openAdditional }
           )}
         >
@@ -113,7 +113,7 @@ const WorkLabelButton: FC<WorkLabelButtonProps> = ({
       className={classNames(
         "py-1 px-4 rounded-full w-max",
         label.active
-          ? "text-primary bg-[#E8EFFF]"
+          ? "text-primary bg-primary-200"
           : "text-secondary-200 bg-light"
       )}
       onClick={onLabelClick}

--- a/frontend/components/kanban/content/work/Label.component.tsx
+++ b/frontend/components/kanban/content/work/Label.component.tsx
@@ -112,7 +112,9 @@ const WorkLabelButton: FC<WorkLabelButtonProps> = ({
       key={label.name}
       className={classNames(
         "py-1 px-4 rounded-full w-max",
-        label.active ? "text-primary bg-[#E8EFFF]" : "text-[#777777] bg-light"
+        label.active
+          ? "text-primary bg-[#E8EFFF]"
+          : "text-secondary-200 bg-light"
       )}
       onClick={onLabelClick}
     >

--- a/frontend/components/kanban/content/work/WorkDetailLeft.component.tsx
+++ b/frontend/components/kanban/content/work/WorkDetailLeft.component.tsx
@@ -70,7 +70,7 @@ const WorkDetailLeft: FC<WorkDetailLeftProps> = ({
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
               />
-              <div className="flex text-sm gap-2 text-[#666666] items-center w-[4rem]">
+              <div className="flex text-sm gap-2 text-secondary-200 items-center w-[4rem]">
                 <button
                   type="submit"
                   onClick={() => setIsOpenAddCard((prev) => !prev)}
@@ -84,13 +84,13 @@ const WorkDetailLeft: FC<WorkDetailLeftProps> = ({
           )}
           <div className="flex gap-2 w-[8rem] justify-end">
             <button
-              className="text-sm text-[#666666] items-center w-fit"
+              className="text-sm text-secondary-200 items-center w-fit"
               onClick={() => setIsOpenAddCard((prev) => !prev)}
             >
               수정
             </button>
             <button
-              className="text-sm text-[#666666] items-center w-fit"
+              className="text-sm text-secondary-200 items-center w-fit"
               onClick={onDeleteWorkCard}
             >
               삭제

--- a/frontend/components/kanban/content/work/WorkDetailRight.component.tsx
+++ b/frontend/components/kanban/content/work/WorkDetailRight.component.tsx
@@ -21,7 +21,7 @@ const WorkDetailRight: FC<WorkDetailRightProps> = ({ data, cardId }) => {
   return (
     <>
       <Txt typography="h2">내용</Txt>
-      <div className="flex text-sm gap-2 text-[#666666] items-center">
+      <div className="flex text-sm gap-2 text-secondary-200 items-center">
         <button onClick={() => setIsEdit((prev) => !prev)}>수정</button>
       </div>
       <WorkEditorOrViewer

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -10,6 +10,7 @@ module.exports = {
       colors: {
         primary: "#2160FF",
         error: "#DC0000",
+        dark: "#303030",
       },
     },
   },

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -12,6 +12,10 @@ module.exports = {
         error: "#DC0000",
         dark: "#303030",
         light: "#F0F0F0",
+        secondary: {
+          100: "#A7A7A7",
+          200: "#666666",
+        },
       },
     },
   },

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -22,6 +22,7 @@ module.exports = {
         secondary: {
           100: "#A7A7A7",
           200: "#666666",
+          DEFAULT: colors.secondary[200],
         },
       },
     },

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -8,7 +8,14 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        primary: "#2160FF",
+        primary: {
+          100: "#F9FBFF",
+          200: "#E8EFFF",
+          300: "#A6BFFF",
+          400: "#7AA0FF",
+          500: "#2160FF",
+          DEFAULT: colors.primary[500],
+        },
         error: "#DC0000",
         dark: "#303030",
         light: "#F0F0F0",

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -11,6 +11,7 @@ module.exports = {
         primary: "#2160FF",
         error: "#DC0000",
         dark: "#303030",
+        light: "#F0F0F0",
       },
     },
   },

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -9,6 +9,7 @@ module.exports = {
     extend: {
       colors: {
         primary: "#2160FF",
+        error: "#DC0000",
       },
     },
   },

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -6,7 +6,11 @@ module.exports = {
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        primary: "#2160FF",
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## 주요 변경사항


### 최종 색상표

<img width="1064" alt="image" src="https://github.com/JNU-econovation/econo-recruit-fe/assets/71962076/85c6c32e-f8f0-4a5c-b2ec-ad517b699dda">

- 유사한 색상은 임의로 통일했습니다.
    - 참고 : [Bootstrap color convention](https://getbootstrap.com/docs/5.0/customize/color/)
- 최종적으로 남은 색상은 크게 5개 / 세부적으로는 10개 입니다.
- 기존 전체 색상을 보고 싶다면 [전체 색상](https://www.figma.com/file/m7iCsNxByJn2C4AJ1p4yri/Untitled?type=design&node-id=0%3A1&mode=design&t=7h9gjsHG73UwfbES-1)에서 확인해주세요.


## 리뷰어에게...

- 색상이 잘못 적용된 부분
- 더 효율적인 색상 정의 방법

위와 같은 부분 위주로 리뷰해주세요!

## 관련 이슈

closes #14 

## 체크리스트

- [x] `reviewers` 설정
- [-] `label` 설정
- [-] `milestone` 설정
