### PR TITLE
fix: tailwind.config color DEFAULT 선언 부분 변경

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -14,7 +14,7 @@ module.exports = {
           300: "#A6BFFF",
           400: "#7AA0FF",
           500: "#2160FF",
-          DEFAULT: colors.primary[500],
+          DEFAULT: "#2160FF",
         },
         error: "#DC0000",
         dark: "#303030",
@@ -22,7 +22,7 @@ module.exports = {
         secondary: {
           100: "#A7A7A7",
           200: "#666666",
-          DEFAULT: colors.secondary[200],
+          DEFAULT: "#666666",
         },
       },
     },


### PR DESCRIPTION
## 주요 변경사항

- 기존에 DEFAULT 값 선언 시 colors 객체를 불러왔는데, 이렇게 사용하면 `colors undefined` 에러가 뜹니다.
- 색상 코드를 바로 할당하는 것으로 변경했습니다. 

## 리뷰어에게...

tailwind theme DEFAULT 값 더 효율적으로 사용하는 방법을 알고 계신다면 조언 해주세요!!

## 관련 이슈

closes #14 

