### PR TITLE
refactor: admin 페이지에 hydration 적용

### DIFF
--- a/frontend/app/(WithNavbar)/admin/[generation]/page.tsx
+++ b/frontend/app/(WithNavbar)/admin/[generation]/page.tsx
@@ -1,52 +1,40 @@
-"use client";
-
+import { dehydrate, Hydrate } from "@tanstack/react-query";
 import AdminBoard from "@/components/admin/Board.component";
 import AdminSearch from "@/components/admin/Search.component";
 import SortList from "@/components/common/SortList";
 import { getAllInterviewerWithOrder } from "@/src/apis/interview";
 import { ORDER_MENU } from "@/src/constants";
-import { useQuery } from "@tanstack/react-query";
+import getQueryClient from "@/src/functions/getQueryClient";
 
 interface AdminPageProps {
   params: {
     generation: string;
   };
   searchParams: {
-    type: string;
     order: string;
-    page: string;
   };
 }
 
-const AdminPage = ({
+const AdminPage = async ({
   params,
-  searchParams: { type = "", order = "", page = "1" },
+  searchParams: { order = "" },
 }: AdminPageProps) => {
-  const { generation } = params;
-
-  const {
-    data: userData,
-    isLoading,
-    isError,
-  } = useQuery(["interviewers"], () => getAllInterviewerWithOrder(order));
-
-  if (!userData || isLoading) {
-    return <div>로딩중...</div>;
-  }
-
-  if (isError) {
-    return <div>에러 발생</div>;
-  }
+  const queryClient = getQueryClient();
+  await queryClient.prefetchQuery({
+    queryKey: ["interviewers"],
+    queryFn: () => getAllInterviewerWithOrder(order),
+  });
+  const dehydrateState = dehydrate(queryClient);
 
   return (
-    <div className="px-24 w-max-[1280px] flex p-12">
-      <div className="flex-1 ml-32 min-w-[46rem] mb-12">
-        <div className="flex w-full justify-end gap-8 my-12">
-          <AdminSearch />
-          <SortList sortList={ORDER_MENU.ADMIN} />
-        </div>
-        <AdminBoard />
+    <div className="flex-1 ml-32 min-w-[46rem] mb-12">
+      <div className="flex w-full justify-end gap-8 my-12">
+        <AdminSearch />
+        <SortList sortList={ORDER_MENU.ADMIN} />
       </div>
+      <Hydrate state={dehydrateState}>
+        <AdminBoard />
+      </Hydrate>
     </div>
   );
 };

--- a/frontend/app/(WithNavbar)/admin/[generation]/page.tsx
+++ b/frontend/app/(WithNavbar)/admin/[generation]/page.tsx
@@ -2,8 +2,8 @@ import { dehydrate, Hydrate } from "@tanstack/react-query";
 import AdminBoard from "@/components/admin/Board.component";
 import AdminSearch from "@/components/admin/Search.component";
 import SortList from "@/components/common/SortList";
-import { getAllInterviewerWithOrder } from "@/src/apis/interview";
 import { ORDER_MENU } from "@/src/constants";
+import { getAllInterviewerWithOrder, getMyInfo } from "@/src/apis/interview";
 import getQueryClient from "@/src/functions/getQueryClient";
 
 interface AdminPageProps {
@@ -24,6 +24,12 @@ const AdminPage = async ({
     queryKey: ["interviewers"],
     queryFn: () => getAllInterviewerWithOrder(order),
   });
+
+  await queryClient.prefetchQuery({
+    queryKey: ["user"],
+    queryFn: getMyInfo,
+  });
+
   const dehydrateState = dehydrate(queryClient);
 
   return (


### PR DESCRIPTION
## 주요 변경사항
admin/[generation]에 interviewers 쿼리와  getMyInfo 쿼리에 대해 hydration을 적용하였습니다.
어제 날린 pr과 유사합니다.
추가로 admin/[generation]에서 안쓰는 prop은 삭제했습니다.

## 리뷰어에게...
데이터를 목적에 맞게 불러오고 있는지 확인해주세요!

## 관련 이슈

closes #42 

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정
