### PR TITLE
fix: 올바르게 navbar가 적용되도록 수정

### DIFF
--- a/frontend/components/common/navbar/Navbar.tsx
+++ b/frontend/components/common/navbar/Navbar.tsx
@@ -21,7 +21,7 @@ const CommonNavbar = ({
         className="flex flex-col font-bold h-36 justify-end text-4xl"
         href="/"
       >
-        {isShort && <div>ECONOVATION</div>}
+        {!isShort && <div>ECONOVATION</div>}
         <div>RECRUIT</div>
         <div>{generation}th</div>
       </Link>


### PR DESCRIPTION
## 주요 변경사항

- 일반 페이지에서 navbar가 원래 모습이 보이도록 합니다. 칸반보드 페이지에서는 짧은 모습이 제대로 보이도록 수정하였습니다.
- 조건문 하나만 고쳐서 크게 볼 부분이 없을 듯 합니다!

[칸판 페이지 fix 전 & 후]

![image](https://github.com/JNU-econovation/econo-recruit-fe/assets/67491015/badca609-bc33-488d-b4f1-de4503ad5fd7)


![image](https://github.com/JNU-econovation/econo-recruit-fe/assets/67491015/670738b8-1b41-4df4-8645-78ce46bec048)

[다른 페이지 fix 전 & 후]

![image](https://github.com/JNU-econovation/econo-recruit-fe/assets/67491015/8f961d63-76a7-4afa-9ce0-45b8bd3e62d0)


![image](https://github.com/JNU-econovation/econo-recruit-fe/assets/67491015/7fbea0c5-7270-4864-99c4-c49589bb5f09)

## 리뷰어에게...

- 조건문 하나만 고쳐서 크게 볼 부분이 없을 듯 합니다!

## 관련 이슈

closes #77 

