### PR TITLE
fix: 업무 전환시 내용이 제대로 보이지 않던 버그 수정

### DIFF
--- a/frontend/components/kanban/content/DetailWork.component.tsx
+++ b/frontend/components/kanban/content/DetailWork.component.tsx
@@ -11,8 +11,10 @@ interface KanbanDetailWorkProps {
 }
 
 const KanbanDetailWork = ({ cardId, generation }: KanbanDetailWorkProps) => {
-  const { data, isLoading, isError } = useQuery(["work", cardId], () =>
-    getWork(cardId)
+  const { data, isLoading, isError } = useQuery(
+    ["work", cardId],
+    () => getWork(cardId),
+    { cacheTime: 0 }
   );
 
   if (!data || isLoading) {

--- a/frontend/components/kanban/content/DetailWork.component.tsx
+++ b/frontend/components/kanban/content/DetailWork.component.tsx
@@ -25,6 +25,8 @@ const KanbanDetailWork = ({ cardId, generation }: KanbanDetailWorkProps) => {
     return <div>에러 발생</div>;
   }
 
+  const { title, content } = data;
+
   return (
     <div className="flex flex-col gap-12 ">
       <div className="ml-24 text-3xl font-bold pb-4 border-b-4">
@@ -35,7 +37,7 @@ const KanbanDetailWork = ({ cardId, generation }: KanbanDetailWorkProps) => {
           <div className="flex flex-1 min-h-0">
             <div className="flex-1 overflow-auto px-12 min-w-[35rem]">
               <WorkDetailLeft
-                data={data}
+                workTitle={title}
                 cardId={+cardId}
                 generation={generation}
               />
@@ -43,7 +45,7 @@ const KanbanDetailWork = ({ cardId, generation }: KanbanDetailWorkProps) => {
           </div>
           <div className="flex flex-1 min-h-0 [box-shadow:0px_0px_6px_1px_rgba(0,0,0,0.14)] mr-12">
             <div className="flex-1 overflow-auto p-12 min-w-[40rem]">
-              <WorkDetailRight data={data.content} cardId={+cardId} />
+              <WorkDetailRight workContent={content} cardId={+cardId} />
             </div>
           </div>
         </div>

--- a/frontend/components/kanban/content/DetailWork.component.tsx
+++ b/frontend/components/kanban/content/DetailWork.component.tsx
@@ -14,7 +14,7 @@ const KanbanDetailWork = ({ cardId, generation }: KanbanDetailWorkProps) => {
   const { data, isLoading, isError } = useQuery(
     ["work", cardId],
     () => getWork(cardId),
-    { cacheTime: 1000 * 60 * 5, staleTime: 1000 * 60 * 5 }
+    { staleTime: 1000 * 60 * 5 }
   );
 
   if (!data || isLoading) {

--- a/frontend/components/kanban/content/DetailWork.component.tsx
+++ b/frontend/components/kanban/content/DetailWork.component.tsx
@@ -14,7 +14,7 @@ const KanbanDetailWork = ({ cardId, generation }: KanbanDetailWorkProps) => {
   const { data, isLoading, isError } = useQuery(
     ["work", cardId],
     () => getWork(cardId),
-    { cacheTime: 0 }
+    { cacheTime: 1000 * 60 * 5, staleTime: 1000 * 60 * 5 }
   );
 
   if (!data || isLoading) {

--- a/frontend/components/kanban/content/work/EditorOrViewer.component.tsx
+++ b/frontend/components/kanban/content/work/EditorOrViewer.component.tsx
@@ -1,7 +1,5 @@
-import { Viewer } from "@toast-ui/react-editor";
+import { Viewer, Editor } from "@toast-ui/react-editor";
 import "@toast-ui/editor/dist/toastui-editor-viewer.css";
-
-import { Editor } from "@toast-ui/react-editor";
 import "@toast-ui/editor/dist/toastui-editor.css";
 
 import { useEffect, useRef, useState } from "react";

--- a/frontend/components/kanban/content/work/EditorOrViewer.component.tsx
+++ b/frontend/components/kanban/content/work/EditorOrViewer.component.tsx
@@ -25,7 +25,7 @@ const WorkEditorOrViewer = ({
   const queryClient = useQueryClient();
 
   const { mutate } = useMutation({
-    mutationFn: () => putWork({ cardId, content }),
+    mutationFn: putWork,
     onSuccess: () =>
       queryClient.invalidateQueries({
         queryKey: ["work"],
@@ -35,7 +35,7 @@ const WorkEditorOrViewer = ({
   const onEdit = () => {
     setContent(editorRef.current?.getInstance().getMarkdown());
     setIsEdit(false);
-    mutate();
+    mutate({ cardId, content });
   };
 
   useEffect(() => {

--- a/frontend/components/kanban/content/work/EditorOrViewer.component.tsx
+++ b/frontend/components/kanban/content/work/EditorOrViewer.component.tsx
@@ -29,7 +29,6 @@ const WorkEditorOrViewer = ({
     onSuccess: () =>
       queryClient.invalidateQueries({
         queryKey: ["work"],
-        refetchType: "active",
       }),
   });
 

--- a/frontend/components/kanban/content/work/WorkDetailLeft.component.tsx
+++ b/frontend/components/kanban/content/work/WorkDetailLeft.component.tsx
@@ -7,7 +7,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 interface WorkDetailLeftProps {
   cardId: number;
-  data: Work;
+  workTitle: string;
   generation: string;
 }
 
@@ -17,7 +17,11 @@ const ApplicantComment = dynamic(
   { ssr: false }
 );
 
-const WorkDetailLeft = ({ data, generation, cardId }: WorkDetailLeftProps) => {
+const WorkDetailLeft = ({
+  workTitle,
+  generation,
+  cardId,
+}: WorkDetailLeftProps) => {
   const [title, setTitle] = useState("");
   const [isOpenAddCard, setIsOpenAddCard] = useState(false);
   const queryClient = useQueryClient();
@@ -50,7 +54,7 @@ const WorkDetailLeft = ({ data, generation, cardId }: WorkDetailLeftProps) => {
   };
 
   useEffect(() => {
-    setTitle(data.title);
+    setTitle(workTitle);
   }, []);
 
   return (
@@ -76,7 +80,7 @@ const WorkDetailLeft = ({ data, generation, cardId }: WorkDetailLeftProps) => {
               </div>
             </form>
           ) : (
-            <Txt typography="h2">{data.title}</Txt>
+            <Txt typography="h2">{workTitle}</Txt>
           )}
           <div className="flex gap-2 w-[8rem] justify-end">
             <button

--- a/frontend/components/kanban/content/work/WorkDetailLeft.component.tsx
+++ b/frontend/components/kanban/content/work/WorkDetailLeft.component.tsx
@@ -22,7 +22,7 @@ const WorkDetailLeft = ({
   generation,
   cardId,
 }: WorkDetailLeftProps) => {
-  const [title, setTitle] = useState("");
+  const [title, setTitle] = useState(workTitle);
   const [isOpenAddCard, setIsOpenAddCard] = useState(false);
   const queryClient = useQueryClient();
 
@@ -52,10 +52,6 @@ const WorkDetailLeft = ({
     if (!confirm("정말 삭제하시겠습니까?")) return;
     deleteWorkCard(`${cardId}`);
   };
-
-  useEffect(() => {
-    setTitle(workTitle);
-  }, []);
 
   return (
     <>

--- a/frontend/components/kanban/content/work/WorkDetailLeft.component.tsx
+++ b/frontend/components/kanban/content/work/WorkDetailLeft.component.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { Work, deleteWork, putWork } from "@/src/apis/work";
+import { useState } from "react";
+import { deleteWork, putWork } from "@/src/apis/work";
 import dynamic from "next/dynamic";
 import Txt from "@/components/common/Txt.component";
 import WorkLabel from "./Label.component";

--- a/frontend/components/kanban/content/work/WorkDetailRight.component.tsx
+++ b/frontend/components/kanban/content/work/WorkDetailRight.component.tsx
@@ -11,11 +11,11 @@ const WorkEditorOrViewer = dynamic(
 );
 
 interface WorkDetailRightProps {
-  data: string;
+  workContent: string;
   cardId: number;
 }
 
-const WorkDetailRight = ({ data, cardId }: WorkDetailRightProps) => {
+const WorkDetailRight = ({ workContent, cardId }: WorkDetailRightProps) => {
   const [isEdit, setIsEdit] = useState(false);
 
   return (
@@ -25,7 +25,7 @@ const WorkDetailRight = ({ data, cardId }: WorkDetailRightProps) => {
         <button onClick={() => setIsEdit((prev) => !prev)}>수정</button>
       </div>
       <WorkEditorOrViewer
-        content={data}
+        content={workContent}
         cardId={cardId}
         setIsEdit={setIsEdit}
         isEdit={isEdit}

--- a/frontend/src/apis/work/index.ts
+++ b/frontend/src/apis/work/index.ts
@@ -20,15 +20,10 @@ export const putWork = async ({
   title?: string;
   content?: string;
 }) => {
-  let resData = {};
-  if (title === "" || !title) {
-    resData = { content };
-  } else if (content === "" || !content) {
-    resData = { title };
-  } else {
-    resData = { title, content };
-  }
-
+  let resData;
+  if (!title) resData = { content };
+  else if (!content) resData = { title };
+  else resData = { title, content };
   const response = await https.put<Work>(`/boards/cards/${cardId}`, resData);
   return response.data;
 };


### PR DESCRIPTION
## 주요 변경사항
[문제 상황](https://github.com/JNU-econovation/econo-recruit-fe/issues/75)
업무 전환시, 기존에 캐싱 타임이 지나지 않은 상태로 기존에 들어갔던 페이지에 들어가게 되면, 가장 최근 렌더링된 모습만 보이는 문제가 존재하였고, 이를 캐싱타임을 없애 매 요청마다 재 랜더링이 되도록 수정하였습니다.

- query의 캐싱타임을 조정하였습니다.
- 코드를 리팩토링 하였습니다.

![업무버그수정](https://github.com/JNU-econovation/econo-recruit-fe/assets/67491015/4b649804-ebd9-4aa8-82a1-a2edb4dd58bc)

## 리뷰어에게...

- 부적절하게 리팩토링 된 부분을 확인해주세요! 
- 추가적인 수정사항이 있는지 확인해주세요!

## 관련 이슈

closes #75 