### PR TITLE
refactor: 댓글 제출 시 바로 화면에 반영되게 한다.

### DIFF
--- a/frontend/components/applicant/applicantNode/comment/InputForm.component.tsx
+++ b/frontend/components/applicant/applicantNode/comment/InputForm.component.tsx
@@ -72,11 +72,17 @@ const ApplicantCommentInputForm = ({
           queryKey: ["kanbanDataArray", generation],
         });
       },
+      onSuccess: () => {
+        editorRef.current?.getInstance().reset();
+        setIsNocomment(false);
+        setHasQuestion(false);
+      },
     }
   );
 
   const onNocommentCheck = useCallback(() => {
-    setIsNocomment(!isNocomment);
+    setIsNocomment((prev) => !prev);
+
     if (editorRef.current) {
       editorRef.current
         .getInstance()
@@ -94,15 +100,7 @@ const ApplicantCommentInputForm = ({
 
     const newContent = (hasQuestion ? "**[질문]** " : "") + content;
     setContent(newContent);
-    return newContent;
-  };
-
-  const onSubmit = () => {
-    const newContent = isPrevSubmit();
-    if (newContent) {
-      mutate();
-      editorRef.current?.getInstance().reset();
-    }
+    return true;
   };
 
   useEffect(() => {
@@ -116,7 +114,7 @@ const ApplicantCommentInputForm = ({
     <form
       onSubmit={(e) => {
         e.preventDefault();
-        onSubmit();
+        isPrevSubmit() && mutate();
       }}
     >
       <div className="flex justify-between items-center pb-2">
@@ -135,14 +133,6 @@ const ApplicantCommentInputForm = ({
           initialEditType="markdown"
           usageStatistics={false}
           language="ko-KR"
-          onChange={() => {
-            isNocomment &&
-              editorRef.current?.getInstance().getMarkdown() !==
-                "지인이므로 코멘트 삼가겠습니다." &&
-              editorRef.current
-                ?.getInstance()
-                .setMarkdown("지인이므로 코멘트 삼가겠습니다.");
-          }}
           ref={editorRef}
         />
       </div>
@@ -152,6 +142,7 @@ const ApplicantCommentInputForm = ({
             name="question"
             id="question"
             title="질문드립니다."
+            checked={hasQuestion}
             onChange={() => setHasQuestion((prev) => !prev)}
           />
           <InputCheckBox

--- a/frontend/components/applicant/applicantNode/comment/InputForm.component.tsx
+++ b/frontend/components/applicant/applicantNode/comment/InputForm.component.tsx
@@ -58,19 +58,16 @@ const ApplicantCommentInputForm = ({
   const editorRef = React.useRef<Editor>(null);
 
   const { mutate } = useMutation(
-    () => {
-      return postComment({
+    () =>
+      postComment({
         content,
         applicantId,
         cardId,
         parentCommentId: 0,
-      });
-    },
+      }),
     {
       onSettled: () => {
-        queryClient.invalidateQueries({
-          queryKey: ["applicantComment", applicantId, cardId],
-        });
+        queryClient.invalidateQueries(["applicantComment"]);
         queryClient.invalidateQueries({
           queryKey: ["kanbanDataArray", generation],
         });

--- a/frontend/components/applicant/applicantNode/comment/InputForm.component.tsx
+++ b/frontend/components/applicant/applicantNode/comment/InputForm.component.tsx
@@ -88,7 +88,7 @@ const ApplicantCommentInputForm = ({
         .getInstance()
         .setMarkdown(isNocomment ? "" : "지인이므로 코멘트 삼가겠습니다.");
     }
-  }, [isNocomment]);
+  }, [isNocomment, setIsNocomment]);
 
   const isPrevSubmit = () => {
     const content = editorRef.current?.getInstance().getMarkdown();

--- a/frontend/components/applicant/applicantNode/comment/InputForm.component.tsx
+++ b/frontend/components/applicant/applicantNode/comment/InputForm.component.tsx
@@ -98,8 +98,7 @@ const ApplicantCommentInputForm = ({
       return false;
     }
 
-    const newContent = (hasQuestion ? "**[질문]** " : "") + content;
-    setContent(newContent);
+    setContent((hasQuestion ? "**[질문]** " : "") + content);
     return true;
   };
 

--- a/frontend/components/applicant/applicantNode/comment/InputForm.component.tsx
+++ b/frontend/components/applicant/applicantNode/comment/InputForm.component.tsx
@@ -95,12 +95,14 @@ const ApplicantCommentInputForm = ({
       return false;
     }
 
-    setContent((prev) => (hasQuestion ? "**[질문]** " : "") + prev);
-    return true;
+    const newContent = (hasQuestion ? "**[질문]** " : "") + content;
+    setContent(newContent);
+    return newContent;
   };
 
   const onSubmit = () => {
-    if (isPrevSubmit()) {
+    const newContent = isPrevSubmit();
+    if (newContent) {
       mutate();
       editorRef.current?.getInstance().reset();
     }


### PR DESCRIPTION
## 주요 변경사항

- 댓글을 제출하면 새로고침을 해야 작성된 댓글이 보이는 이슈
  - invalidateQueries 코드를 수정하였습니다.
- 댓글을 아무런 텍스트 없이 제출 버튼 클릭 후, 다시 텍스트 입력 후 제출하는 경우 제대로 반영되지 않는 버그 발견
  - `isPrevSubmit()` 로직을 수정하였습니다.
- 지코삼을 체크 하면 input 창에 자동으로 텍스트가 들어가는데, 체크를 해제하면 텍스트가 없어지지 않고 그대로 남아있음.
  - Editor 컴포넌트의 onChange 함수를 삭제했습니다. (onNoCommentCheck와 로직 겹침)

## 리뷰어에게...

- 개선할 사항이 있다면 알려주세요!

## 관련 이슈

closes #84 

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정
