### PR TITLE
fix: 점수를 소수점 1자리로 반올림 해서 표시한다.

### DIFF
--- a/frontend/components/interview/modal/score/AvgScore.tsx
+++ b/frontend/components/interview/modal/score/AvgScore.tsx
@@ -11,7 +11,7 @@ const TotalAverage = ({ totalAverage }: TotalAverageProps) => {
   return (
     <div className="w-full relative">
       <p className="w-full text-5xl text-dark font-extrabold text-center">
-        {totalAverage}
+        {+totalAverage.toFixed(1)}
       </p>
       <div className="bg-primary-300 absolute w-full h-5 top-8 -z-10"></div>
     </div>

--- a/frontend/components/interview/modal/score/ScoreCell.tsx
+++ b/frontend/components/interview/modal/score/ScoreCell.tsx
@@ -8,7 +8,9 @@ interface ScoreCellProps {
 const ScoreCell = ({ fieldName, score }: ScoreCellProps) => {
   return (
     <div className="w-[4.5rem] flex flex-col gap-2 items-center">
-      <span className="text-dark text-3xl font-semibold">{score}</span>
+      <span className="text-dark text-3xl font-semibold">
+        {+score.toFixed(1)}
+      </span>
       <span className="text-dark text-center text-sm break-keep">
         {fieldName}
       </span>


### PR DESCRIPTION
## 주요 변경사항

<img width="587" alt="image" src="https://github.com/JNU-econovation/econo-recruit-fe/assets/71962076/5fc40a5e-4d30-492b-89b6-4807030dc215">


- 점수를 소수점 1자리 숫자로 고정했습니다.

## 리뷰어에게...

- toFixed를 사용해서 구현했습니다. 더 좋은 방법이 있다면 추천해주세요!

## 관련 이슈

closes #107 

