### PR TITLE
fix: 동의서 관련 노션 링크를 수정한다

### DIFF
--- a/frontend/components/application/applicationLayout/RadioForCheck.component.tsx
+++ b/frontend/components/application/applicationLayout/RadioForCheck.component.tsx
@@ -25,9 +25,9 @@ const RadioCell = ({
       <Link
         href={
           radioForCheckData.name === "personalInformationAgree"
-            ? "https://lightning-derby-674.notion.site/ad720024b5ab482caaa78419c57b373a?pvs=4"
+            ? "https://candied-goldenrod-7dd.notion.site/c37fad59e43b4685b7212714efdc8756?pvs=4"
             : radioForCheckData.name === "personalInformationAgreeForPortfolio"
-            ? "https://lightning-derby-674.notion.site/50b16833d1c549dba80ba0949a119de1?pvs=4"
+            ? "https://candied-goldenrod-7dd.notion.site/41fafb5c4d794b98b88383285d2c86c3?pvs=4"
             : ""
         }
         target="_blank"


### PR DESCRIPTION
## 주요 변경사항

개인정보수집 관련 전문은 노션으로 연결되기 때문에, 노션 링크를 27기에 맞춰 바꿔뒀습니다.


## 리뷰어에게...

일단 링크를 바꿔두긴 했는데 전문이 노션에 종속되는 것보단 정적 페이지로 만들어서 관리하는 게 더 좋아보입니다..! 바로 작업을 하는 게 좋을까요? 아니면 다음 신입모집부터 적용하는 게 좋을까요?

## 관련 이슈

closes #105 

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정
