### PR TITLE
feat: 최대 글자 제한을 UI에 표시한다

### DIFF
--- a/frontend/components/application/applicationLayout/BooleanTextarea.component.tsx
+++ b/frontend/components/application/applicationLayout/BooleanTextarea.component.tsx
@@ -8,6 +8,7 @@ import type {
   ApplicationQuestion,
 } from "@/src/constants/application/type";
 import { useLocalStorage } from "@/src/hooks/useLocalstorage.hook";
+import { FormEvent } from "react";
 
 interface TextAreaProps {
   node: {
@@ -22,7 +23,7 @@ interface TextAreaProps {
 
 const TextArea = ({ node }: TextAreaProps) => {
   const [textValue, setTextValue] = useLocalStorage(node.name, "");
-  const onInput = (e: React.FormEvent<HTMLTextAreaElement>) => {
+  const onInput = (e: FormEvent<HTMLTextAreaElement>) => {
     setTextValue(e.currentTarget.value.slice(0, MAX_TEXT_LENGTH));
   };
 

--- a/frontend/components/application/applicationLayout/BooleanTextarea.component.tsx
+++ b/frontend/components/application/applicationLayout/BooleanTextarea.component.tsx
@@ -2,6 +2,7 @@
 
 import RadioGroup from "@/components/common/Radio.component";
 import Txt from "@/components/common/Txt.component";
+import { MAX_TEXT_LENGTH } from "@/src/constants";
 import type {
   ApplicationBooleanTextarea,
   ApplicationQuestion,
@@ -21,6 +22,9 @@ interface TextAreaProps {
 
 const TextArea = ({ node }: TextAreaProps) => {
   const [textValue, setTextValue] = useLocalStorage(node.name, "");
+  const onInput = (e: React.FormEvent<HTMLTextAreaElement>) => {
+    setTextValue(e.currentTarget.value.slice(0, MAX_TEXT_LENGTH));
+  };
 
   return (
     <div className="flex gap-6">
@@ -32,15 +36,16 @@ const TextArea = ({ node }: TextAreaProps) => {
           <Txt className="pl-4 block break-keep">{node.subtitle}</Txt>
         </div>
       </div>
-      <div className="flex-1">
+      <div className="flex-1 relative">
         <textarea
-          className="my-2 border rounded-lg p-4 w-full resize-none"
+          className="border rounded-lg px-4 py-6 w-full resize-none"
           rows={20}
           maxLength={1000}
           name={node.name}
           value={textValue}
-          onInput={(e) => setTextValue(e.currentTarget.value)}
+          onInput={onInput}
         />
+        <div className="absolute bottom-3 right-4 bg-white text-sm">{`(${textValue.length}/${MAX_TEXT_LENGTH})`}</div>
       </div>
     </div>
   );

--- a/frontend/components/application/applicationNode/Textarea.component.tsx
+++ b/frontend/components/application/applicationNode/Textarea.component.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Txt from "@/components/common/Txt.component";
+import { MAX_TEXT_LENGTH } from "@/src/constants";
 import {
   ApplicationNode,
   ApplicationTextarea,
@@ -15,6 +16,10 @@ const ApplicationTexarea = ({ data }: ApplicationTextareaProps) => {
   const textData = data as ApplicationTextarea;
   const [value, setValue] = useLocalStorage(textData.name, "");
 
+  const onInput = (e: React.FormEvent<HTMLTextAreaElement>) => {
+    setValue(e.currentTarget.value.slice(0, MAX_TEXT_LENGTH));
+  };
+
   return (
     <>
       {textData.title && (
@@ -25,16 +30,17 @@ const ApplicationTexarea = ({ data }: ApplicationTextareaProps) => {
           {textData.subtitle && <Txt>{` ${textData.subtitle}`}</Txt>}
         </label>
       )}
-      <textarea
-        className="my-2 border rounded-lg p-4 w-full resize-none"
-        rows={20}
-        name={textData.name}
-        value={value}
-        maxLength={1000}
-        onInput={(e) => {
-          setValue(e.currentTarget.value);
-        }}
-      />
+      <div className="relative">
+        <textarea
+          className="border rounded-lg px-4 py-6 w-full resize-none"
+          rows={20}
+          name={textData.name}
+          value={value}
+          maxLength={1000}
+          onInput={onInput}
+        />
+        <div className="absolute bottom-3 right-4 bg-white text-sm">{`(${value.length}/${MAX_TEXT_LENGTH})`}</div>
+      </div>
     </>
   );
 };

--- a/frontend/components/application/applicationNode/Textarea.component.tsx
+++ b/frontend/components/application/applicationNode/Textarea.component.tsx
@@ -7,6 +7,7 @@ import {
   ApplicationTextarea,
 } from "@/src/constants/application/type";
 import { useLocalStorage } from "@/src/hooks/useLocalstorage.hook";
+import { FormEvent } from "react";
 
 interface ApplicationTextareaProps {
   data: ApplicationNode;
@@ -16,7 +17,7 @@ const ApplicationTexarea = ({ data }: ApplicationTextareaProps) => {
   const textData = data as ApplicationTextarea;
   const [value, setValue] = useLocalStorage(textData.name, "");
 
-  const onInput = (e: React.FormEvent<HTMLTextAreaElement>) => {
+  const onInput = (e: FormEvent<HTMLTextAreaElement>) => {
     setValue(e.currentTarget.value.slice(0, MAX_TEXT_LENGTH));
   };
 

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -169,3 +169,5 @@ export const needValidatePath = [
   "/interview",
   "/kanban",
 ];
+
+export const MAX_TEXT_LENGTH = 1000;


### PR DESCRIPTION
## 주요 변경사항

<img width="950" alt="image" src="https://github.com/JNU-econovation/econo-recruit-fe/assets/71962076/ce2593df-647e-4e58-8aee-f04029cad63e">

- 최대 글자수를 신청 페이지에 표시합니다.
- 글자 입력 시 최대 글자수를 넘지 못하도록 핸들러 함수를 추가했습니다.

## 관련 이슈

closes #124 

