### PR TITLE
fix: errormessage를 정상적으로 불러오지 못하는 버그 수정

### DIFF
--- a/frontend/src/functions/axios.ts
+++ b/frontend/src/functions/axios.ts
@@ -25,7 +25,7 @@ https.interceptors.response.use(
     const { data, status: errorStatus } = error.response;
     const { code: errorCode, reason: errorReason } = data;
     const errorMessage =
-      errorConfig[errorCode as ErrorCode].message ||
+      errorConfig[errorCode as ErrorCode]?.message ||
       errorReason ||
       error.message;
 


### PR DESCRIPTION
## 주요 변경사항

axios의 interceptors에서 errorMessage를 올바르게 가져오지 못하여 이후의 로직이 정상적으로 동작하지 않던 버그를 수정하였습니다. 
- errorConfig.message를 옵셔널하게 가져오도록 변경

## 리뷰어에게...

-큰 변경사항이 없습니다! 혹시나 추가적인 버그가 존재할지 확인해주시면 감사하겠습니다!

## 관련 이슈

closes #130 