### PR TITLE
fix: booleanTextarea에서 보내지 못하는 데이터를 보낸다

### DIFF
--- a/frontend/src/functions/getApplication.ts
+++ b/frontend/src/functions/getApplication.ts
@@ -31,6 +31,7 @@ export const getApplicationNames = (
         }
         break;
       case "booleanTextarea":
+        applicationNameSet.add(element.name);
       case "radioByTwoRank":
         if (element.subNodes) {
           element.subNodes.forEach((subNode) => {


### PR DESCRIPTION
## 주요 변경사항

- booleanTextarea에 name이 숨어있었는데, 이를 parsing하지 못했습니다.
- 고로 여기에 고치며 바로 아래 있는 코드까지 의도적으로 break를 걸지 않았습니다. 이를 유념해주세요.

## 리뷰어에게...

## 관련 이슈

- closes #137 

