### PR TITLE
feat: 개인정보 수집 전문 페이지를 구현한다.

### DIFF
--- a/frontend/app/application/consent/page.tsx
+++ b/frontend/app/application/consent/page.tsx
@@ -10,8 +10,8 @@ const ApplicationConsentPage = () => {
   )}.${dateReplacer(FIANL_DATE.date)}`;
 
   return (
-    <>
-      <section className="mx-48 my-32" id="common">
+    <div className="mx-48 [&_section]:my-32">
+      <section id="common">
         <h1 className="font-extrabold text-4xl mb-8">
           <a href="#common">개인정보 수집(공통)에 대한 안내</a>
         </h1>
@@ -37,7 +37,7 @@ const ApplicationConsentPage = () => {
           </p>
         </article>
       </section>
-      <section className="mx-48 my-32" id="portfolio">
+      <section id="portfolio">
         <h1 className="font-extrabold text-4xl mb-8">
           <a href="#portfolio">개인정보 수집(포트폴리오)에 대한 안내</a>
         </h1>
@@ -64,7 +64,7 @@ const ApplicationConsentPage = () => {
           </p>
         </article>
       </section>
-    </>
+    </div>
   );
 };
 

--- a/frontend/app/application/consent/page.tsx
+++ b/frontend/app/application/consent/page.tsx
@@ -1,13 +1,13 @@
 import Txt from "@/components/common/Txt.component";
 import { CURRENT_GENERATION } from "@/src/constants";
-import { FIANL_DATE } from "@/src/constants/application/27";
+import { FINAL_DATE } from "@/src/constants/application/27";
 import { replaceTwoString } from "@/src/functions/replacer";
 
 const ApplicationConsentPage = () => {
   const generation = `${CURRENT_GENERATION}`;
-  const finalDate = `${FIANL_DATE.year}.${replaceTwoString(
-    FIANL_DATE.month
-  )}.${replaceTwoString(FIANL_DATE.date)}`;
+  const finalDate = `${FINAL_DATE.year}.${replaceTwoString(
+    FINAL_DATE.month
+  )}.${replaceTwoString(FINAL_DATE.date)}`;
 
   return (
     <div className="mx-48 [&_section]:my-32">

--- a/frontend/app/application/consent/page.tsx
+++ b/frontend/app/application/consent/page.tsx
@@ -1,0 +1,71 @@
+import Txt from "@/components/common/Txt.component";
+import { CURRENT_GENERATION } from "@/src/constants";
+import { FIANL_DATE } from "@/src/constants/application/27";
+import { dateReplacer } from "@/src/functions/replacer";
+
+const ApplicationConsentPage = () => {
+  const generation = `${CURRENT_GENERATION}`;
+  const finalDate = `${FIANL_DATE.year}.${dateReplacer(
+    FIANL_DATE.month
+  )}.${dateReplacer(FIANL_DATE.date)}`;
+
+  return (
+    <>
+      <section className="mx-48 my-32" id="common">
+        <h1 className="font-extrabold text-4xl mb-8">
+          <a href="#common">개인정보 수집(공통)에 대한 안내</a>
+        </h1>
+        <article className="leading-relaxed">
+          <Txt typography="h6">
+            ECONOVATION은 개인정보보호법 등 관련 법규에 의거하여
+            ‘ECONOVATION&nbsp;{generation}기 신입 모집 지원서’ 수집을 위해
+            아래와 같이 개인 정보를 수집, 이용하고자 합니다.
+            <br /> 내용을 면밀히 읽으신 후 동의 여부를 결정하여 주십시오.
+          </Txt>
+          <p className="py-8">
+            1. 수집 이용 항목 : 전화 번호, 이메일, 이름, 전공, 학번
+            <br /> 2. 수집 이용 목적 : 지원 절차 진행 및 연락
+            <br />
+            3. 보유 기간 : 신입 선발 완료(
+            {finalDate}) 후 1년까지
+          </p>
+          <p>
+            위의 개인 정보 수집 이용에 대한 동의를 거부할 권리가 있습니다.
+            <br />
+            그러나 동의를 거부할 경우 모집 절차를 원활하게 진행할 수 없어 선발에
+            제한을 받을 수 있습니다.
+          </p>
+        </article>
+      </section>
+      <section className="mx-48 my-32" id="portfolio">
+        <h1 className="font-extrabold text-4xl mb-8">
+          <a href="#portfolio">개인정보 수집(포트폴리오)에 대한 안내</a>
+        </h1>
+        <article className="leading-relaxed">
+          <Txt typography="h6">
+            ECONOVATION은 개인정보보호법 등 관련 법규에 의거하여
+            ‘ECONOVATION&nbsp;{generation}기 신입 모집 지원서’ 수집을 위해
+            아래와 같이 개인 정보를 수집, 이용하고자 합니다.
+            <br /> 내용을 면밀히 읽으신 후 동의 여부를 결정하여 주십시오.
+          </Txt>
+          <p className="py-8">
+            1. 서류 이름: 포트폴리오
+            <br /> 2. 수집 이용 항목: 이력, 학력, 경력 등 정보 및 저작권
+            <br />
+            3. 수집 이용 목적: 지원 절차 수행
+            <br /> 4. 보유 기간 : 신입 선발 완료(
+            {finalDate}) 후 1년까지
+          </p>
+          <p>
+            위의 개인 정보 수집 이용에 대한 동의를 거부할 권리가 있습니다.
+            <br />
+            그러나 동의를 거부할 경우 포트폴리오에 대한 심사는 제외되므로 관련
+            잘차에서 불이익을 받을 수 있습니다.
+          </p>
+        </article>
+      </section>
+    </>
+  );
+};
+
+export default ApplicationConsentPage;

--- a/frontend/app/application/consent/page.tsx
+++ b/frontend/app/application/consent/page.tsx
@@ -1,13 +1,13 @@
 import Txt from "@/components/common/Txt.component";
 import { CURRENT_GENERATION } from "@/src/constants";
 import { FIANL_DATE } from "@/src/constants/application/27";
-import { dateReplacer } from "@/src/functions/replacer";
+import { replaceTwoString } from "@/src/functions/replacer";
 
 const ApplicationConsentPage = () => {
   const generation = `${CURRENT_GENERATION}`;
-  const finalDate = `${FIANL_DATE.year}.${dateReplacer(
+  const finalDate = `${FIANL_DATE.year}.${replaceTwoString(
     FIANL_DATE.month
-  )}.${dateReplacer(FIANL_DATE.date)}`;
+  )}.${replaceTwoString(FIANL_DATE.date)}`;
 
   return (
     <div className="mx-48 [&_section]:my-32">

--- a/frontend/components/application/applicationLayout/RadioForCheck.component.tsx
+++ b/frontend/components/application/applicationLayout/RadioForCheck.component.tsx
@@ -31,9 +31,9 @@ const RadioCell = ({
       <Link
         href={
           radioForCheckData.name === "personalInformationAgree"
-            ? "https://candied-goldenrod-7dd.notion.site/c37fad59e43b4685b7212714efdc8756?pvs=4"
+            ? "/application/consent#common"
             : radioForCheckData.name === "personalInformationAgreeForPortfolio"
-            ? "https://candied-goldenrod-7dd.notion.site/41fafb5c4d794b98b88383285d2c86c3?pvs=4"
+            ? "/application/consent#portfolio"
             : ""
         }
         target="_blank"

--- a/frontend/src/constants/application/27.ts
+++ b/frontend/src/constants/application/27.ts
@@ -197,3 +197,9 @@ export const END_DATE = {
   month: 3,
   date: 18,
 };
+
+export const FIANL_DATE = {
+  year: 2024,
+  month: 3,
+  date: 25,
+};

--- a/frontend/src/constants/application/27.ts
+++ b/frontend/src/constants/application/27.ts
@@ -198,7 +198,7 @@ export const END_DATE = {
   date: 18,
 };
 
-export const FIANL_DATE = {
+export const FINAL_DATE = {
   year: 2024,
   month: 3,
   date: 25,

--- a/frontend/src/functions/replacer.ts
+++ b/frontend/src/functions/replacer.ts
@@ -37,4 +37,5 @@ export const replacer = (value: string, type: ReplacerType) => {
   }
 };
 
-export const dateReplacer = (date: number) => date.toString().padStart(2, "0");
+export const replaceTwoString = (original: number, by: string = "0") =>
+  original.toString().padStart(2, by);

--- a/frontend/src/functions/replacer.ts
+++ b/frontend/src/functions/replacer.ts
@@ -36,3 +36,5 @@ export const replacer = (value: string, type: ReplacerType) => {
       return value;
   }
 };
+
+export const dateReplacer = (date: number) => date.toString().padStart(2, "0");


### PR DESCRIPTION
## 주요 변경사항

개인정보 수집(공통, 포트폴리오)에 대한 전문 페이지를 만들었습니다.
동의서가 두개라서 페이지를 따로 만들까 생각도 했지만, 하나에 모아두는 것도 괜찮을 것 같다는 생각에 각각의 section에 id를 지정해두고, a 태그를 통해 해당 id에 이동하는 방식으로 구현했습니다.
(추가로.. 포트폴리오 관련 전문에 잘못된 문구를 발견해서 회장단과 논의하에 바꿨습니다.)
![image](https://github.com/JNU-econovation/econo-recruit-fe/assets/102566546/b44201e5-9fa0-46a9-8ad8-3dfa21f12f25)

## 리뷰어에게...

동의서 두개를 각각 따로 두는 게 나을까요? a 태그를 통해서 이동하게 하긴 했지만 워낙 글이 짧아서 id로 이동한다는 느낌은 크게 안들긴하네요

## 관련 이슈

closes #118 

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정
