### PR TITLE
feat: current generation 업데이트

### DIFF
--- a/frontend/app/(WithNavbar)/layout.tsx
+++ b/frontend/app/(WithNavbar)/layout.tsx
@@ -7,16 +7,11 @@ interface WithNavbarLayout extends PropsWithChildren {}
 const ApplicantPage = ({ children }: WithNavbarLayout) => {
   const headersList = headers();
   const header_url = headersList.get("x-url") || "";
-  const [_, __, currentPath, generation, ___] = header_url.split(/[/?]+/);
-  const isShort = currentPath === "kanban";
+  const [_, __, ___, generation, ____] = header_url.split(/[/?]+/);
 
   return (
     <div className="px-24 min-w-[1280px] flex p-12">
-      <CommonNavbar
-        generation={generation}
-        currentPath={currentPath}
-        isShort={isShort}
-      />
+      <CommonNavbar generation={generation} />
       {children}
     </div>
   );

--- a/frontend/app/(WithNavbar)/layout.tsx
+++ b/frontend/app/(WithNavbar)/layout.tsx
@@ -1,17 +1,12 @@
 import CommonNavbar from "@/components/common/navbar/Navbar";
 import { PropsWithChildren } from "react";
-import { headers } from "next/headers";
 
 interface WithNavbarLayout extends PropsWithChildren {}
 
 const ApplicantPage = ({ children }: WithNavbarLayout) => {
-  const headersList = headers();
-  const header_url = headersList.get("x-url") || "";
-  const [_, __, ___, generation, ____] = header_url.split(/[/?]+/);
-
   return (
     <div className="px-24 min-w-[1280px] flex p-12">
-      <CommonNavbar generation={generation} />
+      <CommonNavbar />
       {children}
     </div>
   );

--- a/frontend/app/(WithNavbar)/layout.tsx
+++ b/frontend/app/(WithNavbar)/layout.tsx
@@ -1,5 +1,5 @@
 import CommonNavbar from "@/components/common/navbar/Navbar";
-import { PropsWithChildren } from "react";
+import { type PropsWithChildren } from "react";
 
 interface WithNavbarLayout extends PropsWithChildren {}
 

--- a/frontend/app/kanban/[generation]/detail/page.tsx
+++ b/frontend/app/kanban/[generation]/detail/page.tsx
@@ -47,12 +47,11 @@ const DetailContentJunction = ({
 
 const KanbanBoardDetailPage = ({
   params: { generation },
-  searchParams: { columnIndex, applicantId, type, cardId },
+  searchParams: { applicantId, type, cardId },
 }: KanbanBoardDetailPageProps) => {
   return (
     <main className="flex mt-8 overflow-auto pt-12 pl-12">
       <KanbanColumnDetailCard
-        columnIndex={+(columnIndex ?? 0)}
         generation={generation}
         cardId={cardId}
         applicantId={applicantId}

--- a/frontend/app/kanban/[generation]/detail/page.tsx
+++ b/frontend/app/kanban/[generation]/detail/page.tsx
@@ -52,7 +52,7 @@ const KanbanBoardDetailPage = ({
   return (
     <main className="flex mt-8 overflow-auto pt-12 pl-12">
       <KanbanColumnDetailCard
-        columnIndex={+columnIndex ?? 0}
+        columnIndex={+(columnIndex ?? 0)}
         generation={generation}
         cardId={cardId}
         applicantId={applicantId}

--- a/frontend/components/common/navbar/Navbar.tsx
+++ b/frontend/components/common/navbar/Navbar.tsx
@@ -24,7 +24,7 @@ const CommonNavbar = () => {
       </Link>
       <div className="flex flex-col gap-8 mt-8 text-xl">
         {MainNavbar(+generation).map((item) => (
-          <CommonNavbarCell key={item.type} item={item} />
+          <CommonNavbarCell key={item.type} {...item} />
         ))}
         <NavbarGenerationToggle />
         <NavbarOperation />

--- a/frontend/components/common/navbar/Navbar.tsx
+++ b/frontend/components/common/navbar/Navbar.tsx
@@ -5,14 +5,12 @@ import NavbarUserInfo from "./UserInfo";
 import { NavbarOperation } from "./NavbarOperation";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { NavbarToggle } from "./NavbarToggle";
 
-interface CommonNavbarProps {
-  generation: string;
-}
-
-const CommonNavbar = ({ generation }: CommonNavbarProps) => {
-  const currentPath = usePathname().split("/")[1];
-  const isShort = currentPath === "kanban";
+const CommonNavbar = () => {
+  const currentPath = usePathname();
+  const isShort = currentPath.split("/")[1] === "kanban";
+  const generation = currentPath.split("/")[2];
 
   return (
     <nav className="flex flex-col transition-all">
@@ -25,10 +23,11 @@ const CommonNavbar = ({ generation }: CommonNavbarProps) => {
         <div>{generation}th</div>
       </Link>
       <div className="flex flex-col gap-8 mt-8 text-xl">
-        {MainNavbar.map((item) => (
+        {MainNavbar(+generation).map((item) => (
           <CommonNavbarCell key={item.type} item={item} />
         ))}
-        <NavbarOperation generation={generation} />
+        <NavbarToggle />
+        <NavbarOperation />
       </div>
       <NavbarUserInfo />
     </nav>

--- a/frontend/components/common/navbar/Navbar.tsx
+++ b/frontend/components/common/navbar/Navbar.tsx
@@ -8,9 +8,8 @@ import { usePathname } from "next/navigation";
 import { NavbarGenerationToggle } from "./NavbarGenerationToggle";
 
 const CommonNavbar = () => {
-  const currentPath = usePathname();
-  const isShort = currentPath.split("/")[1] === "kanban";
-  const generation = currentPath.split("/")[2];
+  const [_, currentType, generation] = usePathname().split("/");
+  const isShort = currentType === "kanban";
 
   return (
     <nav className="flex flex-col transition-all">
@@ -24,10 +23,15 @@ const CommonNavbar = () => {
       </Link>
       <div className="flex flex-col gap-8 mt-8 text-xl">
         {MainNavbar(+generation).map((item) => (
-          <CommonNavbarCell key={item.type} {...item} />
+          <CommonNavbarCell
+            key={item.type}
+            currentType={currentType}
+            isShort={isShort}
+            {...item}
+          />
         ))}
-        <NavbarGenerationToggle />
-        <NavbarOperation />
+        <NavbarGenerationToggle generation={generation} isShort={isShort} />
+        <NavbarOperation currentType={currentType} />
       </div>
       <NavbarUserInfo />
     </nav>

--- a/frontend/components/common/navbar/Navbar.tsx
+++ b/frontend/components/common/navbar/Navbar.tsx
@@ -1,20 +1,19 @@
+"use client";
 import { MainNavbar } from "@/src/constants";
 import CommonNavbarCell from "./NavbarCell";
 import NavbarUserInfo from "./UserInfo";
 import { NavbarOperation } from "./NavbarOperation";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 
 interface CommonNavbarProps {
   generation: string;
-  isShort?: boolean;
-  currentPath: string;
 }
 
-const CommonNavbar = ({
-  generation,
-  isShort = false,
-  currentPath,
-}: CommonNavbarProps) => {
+const CommonNavbar = ({ generation }: CommonNavbarProps) => {
+  const currentPath = usePathname().split("/")[1];
+  const isShort = currentPath === "kanban";
+
   return (
     <nav className="flex flex-col transition-all">
       <Link
@@ -27,13 +26,9 @@ const CommonNavbar = ({
       </Link>
       <div className="flex flex-col gap-8 mt-8 text-xl">
         {MainNavbar.map((item) => (
-          <CommonNavbarCell key={item.type} isShort={isShort} item={item} />
+          <CommonNavbarCell key={item.type} item={item} />
         ))}
-        <NavbarOperation
-          currentPath={currentPath}
-          generation={generation}
-          isShort={isShort}
-        />
+        <NavbarOperation generation={generation} />
       </div>
       <NavbarUserInfo />
     </nav>

--- a/frontend/components/common/navbar/Navbar.tsx
+++ b/frontend/components/common/navbar/Navbar.tsx
@@ -27,12 +27,7 @@ const CommonNavbar = ({
       </Link>
       <div className="flex flex-col gap-8 mt-8 text-xl">
         {MainNavbar.map((item) => (
-          <CommonNavbarCell
-            key={item.type}
-            currentPath={currentPath}
-            isShort={isShort}
-            item={item}
-          />
+          <CommonNavbarCell key={item.type} isShort={isShort} item={item} />
         ))}
         <NavbarOperation
           currentPath={currentPath}

--- a/frontend/components/common/navbar/Navbar.tsx
+++ b/frontend/components/common/navbar/Navbar.tsx
@@ -5,7 +5,7 @@ import NavbarUserInfo from "./UserInfo";
 import { NavbarOperation } from "./NavbarOperation";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { NavbarToggle } from "./NavbarToggle";
+import { NavbarGenerationToggle } from "./NavbarGenerationToggle";
 
 const CommonNavbar = () => {
   const currentPath = usePathname();
@@ -26,7 +26,7 @@ const CommonNavbar = () => {
         {MainNavbar(+generation).map((item) => (
           <CommonNavbarCell key={item.type} item={item} />
         ))}
-        <NavbarToggle />
+        <NavbarGenerationToggle />
         <NavbarOperation />
       </div>
       <NavbarUserInfo />

--- a/frontend/components/common/navbar/NavbarCell.tsx
+++ b/frontend/components/common/navbar/NavbarCell.tsx
@@ -5,20 +5,11 @@ import LtIcon from "@/public/icons/lt.icon.svg";
 import LtIconWhite from "@/public/icons/lt.icon.white.svg";
 import Link from "next/link";
 import { cn } from "@/src/utils/cn";
-import { usePathname } from "next/navigation";
+import { NavbarItem } from "@/src/constants";
 
-export type CommonNavbarCellProps = {
-  title: string;
-  short_title: string;
-  type:
-    | "apply"
-    | "kanban"
-    | "interview"
-    | "applicant"
-    | "sharepoint"
-    | "toggle";
-  target?: "_blank" | "_self" | "_parent" | "_top";
-  href: string;
+export type CommonNavbarCellProps = NavbarItem & {
+  currentType: string;
+  isShort: boolean;
 };
 
 const CommonNavbarCell = ({
@@ -27,10 +18,9 @@ const CommonNavbarCell = ({
   target,
   title,
   type,
+  currentType,
+  isShort,
 }: CommonNavbarCellProps) => {
-  const [_, currentType] = usePathname().split("/");
-  const isShort = currentType === "kanban";
-
   const linkButtonClassName =
     "flex justify-between p-4 hover:bg-secondary-100 hover:text-white rounded-lg";
 

--- a/frontend/components/common/navbar/NavbarCell.tsx
+++ b/frontend/components/common/navbar/NavbarCell.tsx
@@ -18,11 +18,8 @@ type CommonNavbarCellProps = {
 };
 
 const CommonNavbarCell = ({ item }: CommonNavbarCellProps) => {
-  const currentPath = usePathname();
-  const currentType = currentPath.split("/")[1];
+  const [_, currentType] = usePathname().split("/");
   const isShort = currentType === "kanban";
-
-  const generation = currentPath.split("/")[2];
 
   const linkButtonClassName =
     "flex justify-between p-4 hover:bg-secondary-100 hover:text-white rounded-lg";
@@ -42,7 +39,7 @@ const CommonNavbarCell = ({ item }: CommonNavbarCellProps) => {
     >
       {isShort ? short_title : title}
       <Image
-        src={currentPath !== type ? LtIcon : LtIconWhite}
+        src={currentType !== type ? LtIcon : LtIconWhite}
         alt="right arrow"
       />
     </Link>

--- a/frontend/components/common/navbar/NavbarCell.tsx
+++ b/frontend/components/common/navbar/NavbarCell.tsx
@@ -15,12 +15,12 @@ type CommonNavbarCellProps = {
     short_title: string;
     title: string;
   };
-  isShort: boolean;
 };
 
-const CommonNavbarCell = ({ item, isShort }: CommonNavbarCellProps) => {
+const CommonNavbarCell = ({ item }: CommonNavbarCellProps) => {
   const currentPath = usePathname();
   const currentType = currentPath.split("/")[1];
+  const isShort = currentType === "kanban";
 
   const linkButtonClassName =
     "flex justify-between p-4 hover:bg-secondary-100 hover:text-white rounded-lg";

--- a/frontend/components/common/navbar/NavbarCell.tsx
+++ b/frontend/components/common/navbar/NavbarCell.tsx
@@ -7,12 +7,18 @@ import Link from "next/link";
 import { cn } from "@/src/utils/cn";
 import { usePathname } from "next/navigation";
 
-type CommonNavbarCellProps = {
-  type: string; //TODO: 타입 정의하기
-  href: string;
-  target: string;
-  short_title: string;
+export type CommonNavbarCellProps = {
   title: string;
+  short_title: string;
+  type:
+    | "apply"
+    | "kanban"
+    | "interview"
+    | "applicant"
+    | "sharepoint"
+    | "toggle";
+  target?: "_blank" | "_self" | "_parent" | "_top";
+  href: string;
 };
 
 const CommonNavbarCell = ({
@@ -34,7 +40,7 @@ const CommonNavbarCell = ({
         "!bg-black !text-white": currentType === type,
       })}
       href={href}
-      target={target === "_blank" ? "_blank" : ""}
+      target={target}
       key={type}
     >
       {isShort ? short_title : title}

--- a/frontend/components/common/navbar/NavbarCell.tsx
+++ b/frontend/components/common/navbar/NavbarCell.tsx
@@ -22,6 +22,8 @@ const CommonNavbarCell = ({ item }: CommonNavbarCellProps) => {
   const currentType = currentPath.split("/")[1];
   const isShort = currentType === "kanban";
 
+  const generation = currentPath.split("/")[2];
+
   const linkButtonClassName =
     "flex justify-between p-4 hover:bg-secondary-100 hover:text-white rounded-lg";
 

--- a/frontend/components/common/navbar/NavbarCell.tsx
+++ b/frontend/components/common/navbar/NavbarCell.tsx
@@ -8,23 +8,25 @@ import { cn } from "@/src/utils/cn";
 import { usePathname } from "next/navigation";
 
 type CommonNavbarCellProps = {
-  item: {
-    type: string; //TODO: 타입 정의하기
-    href: string;
-    target: string;
-    short_title: string;
-    title: string;
-  };
+  type: string; //TODO: 타입 정의하기
+  href: string;
+  target: string;
+  short_title: string;
+  title: string;
 };
 
-const CommonNavbarCell = ({ item }: CommonNavbarCellProps) => {
+const CommonNavbarCell = ({
+  href,
+  short_title,
+  target,
+  title,
+  type,
+}: CommonNavbarCellProps) => {
   const [_, currentType] = usePathname().split("/");
   const isShort = currentType === "kanban";
 
   const linkButtonClassName =
     "flex justify-between p-4 hover:bg-secondary-100 hover:text-white rounded-lg";
-
-  const { href, short_title, target, title, type } = item;
 
   return (
     <Link

--- a/frontend/components/common/navbar/NavbarCell.tsx
+++ b/frontend/components/common/navbar/NavbarCell.tsx
@@ -28,11 +28,9 @@ const CommonNavbarCell = ({ item }: CommonNavbarCellProps) => {
 
   return (
     <Link
-      className={cn(
-        currentType === type
-          ? `${linkButtonClassName} !bg-black !text-white`
-          : linkButtonClassName
-      )}
+      className={cn(linkButtonClassName, {
+        "!bg-black !text-white": currentType === type,
+      })}
       href={href}
       target={target === "_blank" ? "_blank" : ""}
       key={type}

--- a/frontend/components/common/navbar/NavbarCell.tsx
+++ b/frontend/components/common/navbar/NavbarCell.tsx
@@ -1,11 +1,15 @@
+"use client";
+
 import Image from "next/image";
 import LtIcon from "@/public/icons/lt.icon.svg";
 import LtIconWhite from "@/public/icons/lt.icon.white.svg";
+import Link from "next/link";
+import { cn } from "@/src/utils/cn";
+import { usePathname } from "next/navigation";
 
 type CommonNavbarCellProps = {
-  currentPath: string;
   item: {
-    type: string;
+    type: string; //TODO: 타입 정의하기
     href: string;
     target: string;
     short_title: string;
@@ -14,30 +18,32 @@ type CommonNavbarCellProps = {
   isShort: boolean;
 };
 
-const CommonNavbarCell = ({
-  currentPath,
-  item,
-  isShort,
-}: CommonNavbarCellProps) => {
+const CommonNavbarCell = ({ item, isShort }: CommonNavbarCellProps) => {
+  const currentPath = usePathname();
+  const currentType = currentPath.split("/")[1];
+
   const linkButtonClassName =
     "flex justify-between p-4 hover:bg-secondary-100 hover:text-white rounded-lg";
+
+  const { href, short_title, target, title, type } = item;
+
   return (
-    <a
-      className={
-        currentPath === item.type
+    <Link
+      className={cn(
+        currentType === type
           ? `${linkButtonClassName} !bg-black !text-white`
           : linkButtonClassName
-      }
-      href={item.href}
-      target={item.target === "_blank" ? "_blank" : ""}
-      key={item.type}
+      )}
+      href={href}
+      target={target === "_blank" ? "_blank" : ""}
+      key={type}
     >
-      {isShort ? item.short_title : item.title}
+      {isShort ? short_title : title}
       <Image
-        src={currentPath !== item.type ? LtIcon : LtIconWhite}
+        src={currentPath !== type ? LtIcon : LtIconWhite}
         alt="right arrow"
       />
-    </a>
+    </Link>
   );
 };
 

--- a/frontend/components/common/navbar/NavbarGenerationToggle.tsx
+++ b/frontend/components/common/navbar/NavbarGenerationToggle.tsx
@@ -21,7 +21,6 @@ export const NavbarGenerationToggle = () => {
       href={`/kanban/${generation}`}
       short_title={short_title}
       title={title}
-      target="_self"
       type="toggle"
     />
   );

--- a/frontend/components/common/navbar/NavbarGenerationToggle.tsx
+++ b/frontend/components/common/navbar/NavbarGenerationToggle.tsx
@@ -1,13 +1,16 @@
-import { usePathname } from "next/navigation";
 import CommonNavbarCell from "./NavbarCell";
 import { CURRENT_GENERATION } from "@/src/constants";
 
-export const NavbarGenerationToggle = () => {
-  const currentPath = usePathname();
-  const selectedGeneration = +currentPath.split("/")[2];
-
-  const isCurrentGeneration = selectedGeneration === CURRENT_GENERATION;
-  const generation = isCurrentGeneration
+type NavbarGenerationToggleProps = {
+  generation: string;
+  isShort: boolean;
+};
+export const NavbarGenerationToggle = ({
+  generation,
+  isShort,
+}: NavbarGenerationToggleProps) => {
+  const isCurrentGeneration = +generation === CURRENT_GENERATION;
+  const targetGeneration = isCurrentGeneration
     ? CURRENT_GENERATION - 1
     : CURRENT_GENERATION;
 
@@ -18,7 +21,9 @@ export const NavbarGenerationToggle = () => {
 
   return (
     <CommonNavbarCell
-      href={`/kanban/${generation}`}
+      currentType="kanban"
+      isShort={isShort}
+      href={`/kanban/${targetGeneration}`}
       short_title={short_title}
       title={title}
       type="toggle"

--- a/frontend/components/common/navbar/NavbarGenerationToggle.tsx
+++ b/frontend/components/common/navbar/NavbarGenerationToggle.tsx
@@ -18,13 +18,11 @@ export const NavbarGenerationToggle = () => {
 
   return (
     <CommonNavbarCell
-      item={{
-        href: `/kanban/${generation}`,
-        short_title,
-        title,
-        target: "_self",
-        type: "toggle",
-      }}
+      href={`/kanban/${generation}`}
+      short_title={short_title}
+      title={title}
+      target="_self"
+      type="toggle"
     />
   );
 };

--- a/frontend/components/common/navbar/NavbarGenerationToggle.tsx
+++ b/frontend/components/common/navbar/NavbarGenerationToggle.tsx
@@ -2,7 +2,7 @@ import { usePathname } from "next/navigation";
 import CommonNavbarCell from "./NavbarCell";
 import { CURRENT_GENERATION } from "@/src/constants";
 
-export const NavbarToggle = () => {
+export const NavbarGenerationToggle = () => {
   const currentPath = usePathname();
   const selectedGeneration = +currentPath.split("/")[2];
 

--- a/frontend/components/common/navbar/NavbarOperation.tsx
+++ b/frontend/components/common/navbar/NavbarOperation.tsx
@@ -5,7 +5,10 @@ import CommonNavbarCell from "./NavbarCell";
 import { getMyInfo } from "@/src/apis/interview";
 import { usePathname } from "next/navigation";
 
-export const NavbarOperation = () => {
+type NavbarOperationProps = {
+  currentType: string;
+};
+export const NavbarOperation = ({ currentType }: NavbarOperationProps) => {
   const currentPath = usePathname();
   const generation = currentPath.split("/")[2];
   const { data: userData } = useQuery(["user"], getMyInfo);
@@ -19,6 +22,8 @@ export const NavbarOperation = () => {
 
   return (
     <CommonNavbarCell
+      currentType={currentType}
+      isShort={false}
       href={`/admin/${generation}`}
       short_title="관리자"
       title="관리자 페이지"

--- a/frontend/components/common/navbar/NavbarOperation.tsx
+++ b/frontend/components/common/navbar/NavbarOperation.tsx
@@ -3,16 +3,11 @@
 import { useQuery } from "@tanstack/react-query";
 import CommonNavbarCell from "./NavbarCell";
 import { getMyInfo } from "@/src/apis/interview";
+import { usePathname } from "next/navigation";
 
-interface NavbarOperationProps {
-  generation: string;
-  isShort?: boolean;
-}
-
-export const NavbarOperation = ({
-  generation,
-  isShort = false,
-}: NavbarOperationProps) => {
+export const NavbarOperation = () => {
+  const currentPath = usePathname();
+  const generation = currentPath.split("/")[2];
   const { data: userData } = useQuery(["user"], getMyInfo);
   if (!userData) {
     return <div></div>;

--- a/frontend/components/common/navbar/NavbarOperation.tsx
+++ b/frontend/components/common/navbar/NavbarOperation.tsx
@@ -26,7 +26,6 @@ export const NavbarOperation = ({
 
   return (
     <CommonNavbarCell
-      currentPath={currentPath}
       isShort={isShort}
       item={{
         href: `/admin/${generation}`,

--- a/frontend/components/common/navbar/NavbarOperation.tsx
+++ b/frontend/components/common/navbar/NavbarOperation.tsx
@@ -7,13 +7,11 @@ import { getMyInfo } from "@/src/apis/interview";
 interface NavbarOperationProps {
   generation: string;
   isShort?: boolean;
-  currentPath: string;
 }
 
 export const NavbarOperation = ({
   generation,
   isShort = false,
-  currentPath,
 }: NavbarOperationProps) => {
   const { data: userData } = useQuery(["user"], getMyInfo);
   if (!userData) {
@@ -26,7 +24,6 @@ export const NavbarOperation = ({
 
   return (
     <CommonNavbarCell
-      isShort={isShort}
       item={{
         href: `/admin/${generation}`,
         short_title: "관리자",

--- a/frontend/components/common/navbar/NavbarOperation.tsx
+++ b/frontend/components/common/navbar/NavbarOperation.tsx
@@ -19,13 +19,11 @@ export const NavbarOperation = () => {
 
   return (
     <CommonNavbarCell
-      item={{
-        href: `/admin/${generation}`,
-        short_title: "관리자",
-        title: "관리자 페이지",
-        target: "_self",
-        type: "admin",
-      }}
+      href={`/admin/${generation}`}
+      short_title="관리자"
+      title="관리자 페이지"
+      target="_self"
+      type="admin"
     />
   );
 };

--- a/frontend/components/common/navbar/NavbarToggle.tsx
+++ b/frontend/components/common/navbar/NavbarToggle.tsx
@@ -1,0 +1,30 @@
+import { usePathname } from "next/navigation";
+import CommonNavbarCell from "./NavbarCell";
+import { CURRENT_GENERATION } from "@/src/constants";
+
+export const NavbarToggle = () => {
+  const currentPath = usePathname();
+  const selectedGeneration = +currentPath.split("/")[2];
+
+  const isCurrentGeneration = selectedGeneration === CURRENT_GENERATION;
+  const generation = isCurrentGeneration
+    ? CURRENT_GENERATION - 1
+    : CURRENT_GENERATION;
+
+  const short_title = isCurrentGeneration ? "지난 모집" : "현재 모집";
+  const title = isCurrentGeneration
+    ? "지난 신입모집 보기"
+    : "현재 신입모집 보기";
+
+  return (
+    <CommonNavbarCell
+      item={{
+        href: `/kanban/${generation}`,
+        short_title,
+        title,
+        target: "_self",
+        type: "toggle",
+      }}
+    />
+  );
+};

--- a/frontend/components/kanban/column/ColumnWithBackButton.component.tsx
+++ b/frontend/components/kanban/column/ColumnWithBackButton.component.tsx
@@ -1,28 +1,30 @@
 "use client";
 
 import { KanbanColumnData } from "@/src/stores/kanban/Kanban.atoms";
-import { useAtom } from "jotai";
+import { useAtomValue } from "jotai";
 import { useQuery } from "@tanstack/react-query";
 import { getAllKanbanData } from "@/src/apis/kanban";
 import { KanbanSelectedButtonNumberState } from "@/src/stores/kanban/Navbar.atoms";
 import KanbanDetailBackButton from "../BackButton.component";
 import KanbanCardComponent from "../card/Card.component";
 import Icon from "@/components/common/Icon";
+import { useSearchParams } from "next/navigation";
 
 interface KanbanDetailCardProps {
-  columnIndex: number;
   generation: string;
   cardId: string;
   applicantId: string;
 }
 
 const KanbanColumnDetailCard = ({
-  columnIndex,
   generation,
   cardId,
   applicantId,
 }: KanbanDetailCardProps) => {
-  const [navbarId] = useAtom(KanbanSelectedButtonNumberState);
+  const searchParams = useSearchParams();
+  const columnIndex = +(searchParams.get("columnIndex") ?? "0");
+
+  const navbarId = useAtomValue(KanbanSelectedButtonNumberState);
 
   const {
     data: kanbanDataArray,

--- a/frontend/public/icons/lt.icon.white.svg
+++ b/frontend/public/icons/lt.icon.white.svg
@@ -1,3 +1,3 @@
-<svg width="20" height="19" viewBox="0 0 20 19" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M7.90399 14.1416L12.592 9.45362L7.90399 4.76562" stroke="white" stroke-width="2.344" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="8" height="13" viewBox="0 0 8 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.90397 11.1415L6.59197 6.4535L1.90397 1.7655" stroke="white" stroke-width="2.344" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/frontend/src/constants/applicant/28.ts
+++ b/frontend/src/constants/applicant/28.ts
@@ -1,0 +1,84 @@
+const APPLICANT: ApplicantNode[] = [
+  {
+    id: 1,
+    title: "프로젝트 희망 분야를 선택해주세요.*",
+    type: "customField",
+    value: {
+      name: "field",
+    },
+    subValue: [
+      { title: "1순위", name: "field1" },
+      { title: "2순위", name: "field2" },
+    ],
+  },
+  {
+    id: 2,
+    title: "기본 인적 사항을 입력해주세요.",
+    type: "customHuman",
+    value: {
+      hunamName: { name: "name" },
+      humanEmail: { name: "email" },
+      humanPhone: { name: "contacted" },
+      humanEtc: [
+        { name: "classOf" },
+        { name: "major" },
+        { name: "doubleMajor" },
+        { name: "minor" },
+        { name: "grade" },
+        { name: "semester" },
+        { name: "registered" },
+      ],
+    },
+  },
+  {
+    id: 3,
+    title: "기타 질문 사항에 답변해주세요.",
+    type: "shortSplit",
+    value: [
+      { title: "향후 계획 활동", name: "activity" },
+      { title: "지원 경로* (중복 선택 가능)", name: "channel" },
+    ],
+  },
+];
+
+export type ScoreKeyword =
+  | "실천력"
+  | "동아리 활동의지"
+  | "협업"
+  | "베풀려는 마음";
+
+// type ScoreKeywordName =
+//   | "passion"
+//   | "clubInvolvement"
+//   | "collaboration"
+//   | "devotion";
+
+export const ScoreSequence: {
+  [key: number]: ScoreKeyword;
+} = {
+  0: "실천력",
+  1: "동아리 활동의지",
+  2: "협업",
+  3: "베풀려는 마음",
+};
+
+export type Score = {
+  fieldName: ScoreKeyword;
+  score: number | "";
+};
+
+// type ScoreKeywordType = {
+//   title: ScoreKeyword;
+//   name: ScoreKeywordName;
+// };
+
+// const INTERVIEW_SCORE_KEYWORD: ScoreKeywordType[] = [
+//   { title: "실천력", name: "passion" },
+//   { title: "동아리 활동의지", name: "clubInvolvement" },
+//   { title: "협업", name: "collaboration" },
+//   { title: "베풀려는 마음", name: "devotion" },
+// ];
+
+const FIELD_NAME: ScoreKeyword[] = Object.values(ScoreSequence);
+
+export { APPLICANT, FIELD_NAME };

--- a/frontend/src/constants/applicant/28/designer.ts
+++ b/frontend/src/constants/applicant/28/designer.ts
@@ -1,0 +1,76 @@
+export const APPLICANT_DESIGNER = [
+  {
+    id: 5,
+    title: "자기소개 및 에코노베이션에 지원하게 된 계기를 서술해 주세요.",
+    type: "textarea",
+    value: { name: "reason" },
+  } as ApplicantTextareaNode,
+  {
+    id: 6,
+    title:
+      "본인이 계획하고 있는 진로가 무엇인가요?(IT 분야가 아니어도 괜찮습니다)",
+    type: "textarea",
+    value: { name: "future" },
+  } as ApplicantTextareaNode,
+  {
+    id: 7,
+    title:
+      "UI/UX 디자인 작업물들 중 가장 자신 있는 디자인 작업물을 설명하고, 이를 통해 배우게 된 점이 있다면 서술해 주세요.",
+    type: "textarea",
+    value: { name: "workDescript" },
+  } as ApplicantTextareaNode,
+  {
+    id: 8,
+    title:
+      "UI/UX 디자인을 할 때, 가장 중요한 것은 무엇이라고 생각하나요? 한가지 키워드를 중심으로 서술해주세요.",
+    type: "textarea",
+    value: { name: "keyword" },
+  } as ApplicantTextareaNode,
+  {
+    id: 9,
+    title:
+      "우리 주변의 IT 서비스 중에 UI/UX를 개선하고 싶은 서비스가 있다면, 어떤 점을 '왜' 그리고 '어떻게' 개선하고 싶은지 서술해 주세요.",
+    type: "textarea",
+    value: { name: "betterment" },
+  } as ApplicantTextareaNode,
+  {
+    id: 10,
+    title:
+      "어떤 일에 도전하고 실패해 본 경험이 있나요? 그 실패를 어떻게 극복했는지 서술해 주세요.(소프트웨어 분야 관련 경험이 아니어도 좋습니다.)",
+    type: "textarea",
+    value: { name: "failure" },
+  } as ApplicantTextareaNode,
+  {
+    id: 11,
+    title:
+      "무언가에 깊게 빠지거나 파고 들어본 적이 있나요? 좋아하는 것을 위해서 주변에서 인정할 정도로 깊게 빠져본 적이 있다면 서술해주세요.",
+    type: "textarea",
+    value: { name: "drain" },
+  } as ApplicantTextareaNode,
+  {
+    id: 12,
+    title:
+      "협업(프로젝트, 팀 활동)에 있어서 가장 중요하다고 생각되는 것은 무엇인지 그 이유와 함께 서술해주세요.",
+    type: "textarea",
+    value: { name: "collaboration" },
+  } as ApplicantTextareaNode,
+  {
+    id: 13,
+    title:
+      "에코노베이션에 최종 합격 시 신입 기수로 구성된 팀으로 개발 프로젝트에 참여하고, 목표를 달성하기 위해 스스로 끊임없이 배우고 노력합니다. 에코노베이션에 들어오게 된다면 어떤 목표와 학습 계획을 바탕으로 활동하고 싶나요?",
+    type: "textarea",
+    value: { name: "studyPlan" },
+  } as ApplicantTextareaNode,
+  {
+    id: 14,
+    title:
+      "에코노베이션은 3학기 이상의 활동을 권장하고 있으며 매주 금요일 17시에는 주간발표가 있습니다. 위 내용을 확인하셨으면 '확인했습니다'를 기입해주세요.",
+    type: "textarea",
+    value: { name: "check" },
+  } as ApplicantTextareaNode,
+  {
+    id: 15,
+    title: "면접 가능시간을 선택해주세요. (중복 선택 가능)",
+    type: "timeline",
+  } as ApplicantTimelineNode,
+];

--- a/frontend/src/constants/applicant/28/developer.ts
+++ b/frontend/src/constants/applicant/28/developer.ts
@@ -1,0 +1,67 @@
+export const APPLICANT_DEVELOPER = [
+  {
+    id: 5,
+    title: "자기소개 및 에코노베이션에 지원하게 된 계기를 서술해 주세요.",
+    type: "textarea",
+    value: { name: "reason" },
+  } as ApplicantTextareaNode,
+  {
+    id: 6,
+    title:
+      "개발자를 희망하는 이유는 무엇인가요? 계획하고 계신 진로와 이를 위해 노력한 내용을 말씀해 주세요.",
+    type: "textarea",
+    value: { name: "future" },
+  } as ApplicantTextareaNode,
+  {
+    id: 7,
+    title:
+      "소프트웨어 프로젝트에서 주도적으로 개발한 경험이 있나요?(캡스톤 디자인 제외)",
+    type: "booleanTextarea",
+    booleanValue: { name: "experience" },
+    subtitle: [
+      "본인이 어떤 역할을 했고, 그 경험을 통해 무엇을 얻었는지 서술해 주세요.",
+      "앞으로 해보고 싶은 프로젝트가 무엇인가요? 그 이유와 함께 서술해 주세요.",
+    ],
+    value: { name: "experienceTextarea" },
+  } as ApplicantBooleanTextareaNode,
+  {
+    id: 8,
+    title:
+      "어떤 일에 도전하고 실패해 본 경험이 있나요? 그 실패를 어떻게 극복했는지 서술해 주세요.",
+    type: "textarea",
+    value: { name: "restoration" },
+  } as ApplicantTextareaNode,
+  {
+    id: 9,
+    title:
+      "무언가에 깊게 빠지거나 파고 들어본 적이 있나요? 좋아하는 것을 위해서 주변에서 인정할 정도로 깊게  빠져본 적이 있다면 서술해주세요.",
+    type: "textarea",
+    value: { name: "deep" },
+  } as ApplicantTextareaNode,
+  {
+    id: 10,
+    title:
+      "협업(프로젝트, 팀 활동)에 있어서 가장 중요하다고 생각되는 것은 무엇인지 그 이유와 함께 지원자님의 생각을 서술해 주세요.",
+    type: "textarea",
+    value: { name: "collaboration" },
+  } as ApplicantTextareaNode,
+  {
+    id: 11,
+    title:
+      "에코노베이션에 최종 합격 시 신입 기수로 구성된 팀으로 개발 프로젝트에 참여하고, 목표를 달성하기 위해 스스로 끊임없이 배우고 노력합니다. 에코노베이션에 들어오게 된다면 어떤 목표와 학습 계획을 바탕으로 활동하고 싶나요?",
+    type: "textarea",
+    value: { name: "studyPlan" },
+  } as ApplicantTextareaNode,
+  {
+    id: 12,
+    title:
+      "에코노베이션은 3학기 이상의 활동을 권장하고 있으며 매주 금요일 17시에는 주간발표가 있습니다. 위 내용을 확인하셨으면 '확인했습니다'를 기입해주세요.",
+    type: "textarea",
+    value: { name: "check" },
+  } as ApplicantTextareaNode,
+  {
+    id: 13,
+    title: "면접 가능시간을 선택해주세요. (중복 선택 가능)",
+    type: "timeline",
+  } as ApplicantTimelineNode,
+];

--- a/frontend/src/constants/applicant/28/manager.ts
+++ b/frontend/src/constants/applicant/28/manager.ts
@@ -1,0 +1,74 @@
+export const APPLICANT_MANAGER = [
+  {
+    id: 5,
+    title: "자기소개 및 에코노베이션에 지원하게 된 계기를 서술해 주세요.",
+    type: "textarea",
+    value: { name: "reason" },
+  } as ApplicantTextareaNode,
+  {
+    id: 6,
+    title:
+      "본인이 계획하고 있는 진로가 무엇인가요? (IT 분야가 아니어도 괜찮습니다.)",
+    type: "textarea",
+    value: { name: "future" },
+  } as ApplicantTextareaNode,
+  {
+    id: 7,
+    title:
+      "PM(기획자)은 아이디어를 낼 뿐만 아니라, 자신의 아이디어를 동료들이 이해할 수 있는 형식으로 효과적으로 전달해야 하는 역할입니다. 지원자님께서 자신의 아이디어를 시각적으로 구현하여, 구체적으로 전달한 경험이 있다면 서술해 주세요. 어떤 아이디어를 어떤 형태로 구현하여, 누구에게 전달했는지 잘 드러나도록 작성해 주세요.",
+    type: "textarea",
+    value: { name: "communication" },
+  } as ApplicantTextareaNode,
+  {
+    id: 8,
+    title:
+      "지원자님께서 직접 IT 서비스(UI/UX)를 설계하거나 개선한 경험이 있나요?(캡스톤 디자인 제외)",
+    type: "booleanTextarea",
+    booleanValue: { name: "experience" },
+    subtitle: [
+      "본인이 어떤 역할을 했고, 그 경험을 통해 무엇을 얻었는지 서술해 주세요.",
+      "우리 주변의 IT서비스 중에 개선하고 싶은 서비스가 있다면, 어떤 점을 '왜' 그리고 '어떻게' 개선하고 싶은지 서술해 주세요.",
+    ],
+    value: { name: "experienceTextarea" },
+  } as ApplicantBooleanTextareaNode,
+  {
+    id: 8,
+    title:
+      "어떤 일에 도전하고 실패해 본 경험이 있나요? 그 실패를 어떻게 극복했는지 서술해 주세요. (소프트웨어 분야 관련 경험이 아니어도 좋습니다.)",
+    type: "textarea",
+    value: { name: "failual" },
+  } as ApplicantTextareaNode,
+  {
+    id: 9,
+    title:
+      "무언가에 깊게 빠지거나 파고 들어본 적이 있나요? 좋아하는 것을 위해서 주변에서 인정할 정도로 깊게  빠져본 적이 있다면 서술해주세요. (소프트웨어 분야 관련 경험이 아니어도 좋습니다.)",
+    type: "textarea",
+    value: { name: "deep" },
+  } as ApplicantTextareaNode,
+  {
+    id: 10,
+    title:
+      "협업(프로젝트, 팀 활동)에 있어서 가장 중요하다고 생각되는 것은 무엇인지 그 이유와 함께 지원자님의 생각을 서술해 주세요.",
+    type: "textarea",
+    value: { name: "collaboration" },
+  } as ApplicantTextareaNode,
+  {
+    id: 11,
+    title:
+      "에코노베이션에 최종 합격 시 신입 기수로 구성된 팀으로 개발 프로젝트에 참여하고, 목표를 달성하기 위해 스스로 끊임없이 배우고 노력합니다. 에코노베이션에 들어오게 된다면 어떤 목표와 학습 계획을 바탕으로 활동하고 싶나요?",
+    type: "textarea",
+    value: { name: "studyPlan" },
+  } as ApplicantTextareaNode,
+  {
+    id: 12,
+    title:
+      "에코노베이션은 3학기 이상의 활동을 권장하고 있으며 매주 금요일 17시에는 주간발표가 있습니다. 위 내용을 확인하셨으면 '확인했습니다'를 기입해주세요.",
+    type: "textarea",
+    value: { name: "check" },
+  } as ApplicantTextareaNode,
+  {
+    id: 13,
+    title: "면접 가능시간을 선택해주세요. (중복 선택 가능)",
+    type: "timeline",
+  } as ApplicantTimelineNode,
+];

--- a/frontend/src/constants/application/28.ts
+++ b/frontend/src/constants/application/28.ts
@@ -1,0 +1,205 @@
+import type { ApplicationQuestion, ApplicationTimeline } from "./type";
+
+export const APPLICATION: ApplicationQuestion[] = [
+  {
+    id: 1,
+    title: "프로젝트 희망 분야를 선택해주세요.",
+    subtitle: "2순위가 없다면 '없음'을 선택해주세요.",
+    direction: "horizontal",
+    require: true,
+    nodes: [
+      {
+        type: "radio",
+        name: "field",
+        require: true,
+        value: ["개발자", "디자이너", "기획자"],
+      },
+      {
+        type: "radioByTwoRank",
+        require: true,
+        name: "",
+        subNodes: [
+          {
+            splitNumber: 3,
+            title: "1순위",
+            name: "field1",
+            require: true,
+            value: ["APP", "WEB", "GAME", "AI"],
+          },
+          {
+            splitNumber: 3,
+            title: "2순위",
+            name: "field2",
+            require: true,
+            value: ["APP", "WEB", "GAME", "AI", "선택없음"],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 2,
+    title: "기본 인적 사항을 입력해주세요.",
+    direction: "horizontal",
+    require: false,
+    nodes: [
+      {
+        type: "text",
+        name: "name",
+        title: "이름",
+        maxLength: 5,
+        require: true,
+        errorMessages: "이름을 입력해주세요.",
+      },
+      {
+        type: "text",
+        name: "contacted",
+        title: "연락처",
+        subtitle:
+          "서류가 접수되면 접수 확인 문자가 발송될 예정이니, 연락처를 정확하게 기입해 주시기 바랍니다.",
+        require: true,
+        replace: "cellPhoneNumber",
+        validate: "cellPhoneNumber",
+        errorMessages: "연락처를 입력해주세요.",
+        maxLength: 13,
+      },
+      {
+        type: "text",
+        name: "classOf",
+        title: "학번",
+        subtitle: "(ex. 123456)",
+        require: true,
+        replace: "undergradeNumber",
+        validate: "undergradeNumber",
+        maxLength: 6,
+        errorMessages: "학번을 입력해주세요.",
+      },
+      {
+        type: "text",
+        name: "registered",
+        title: "학적상태(재학 or 휴학)",
+        subtitle: "'휴학'일 경우 복학 예정 시기를 기재해 주세요.",
+        require: true,
+        errorMessages: "학적상태를 입력해주세요.",
+      },
+      {
+        type: "radioByTwoRank",
+        title: "학년 및 학기",
+        name: "",
+        require: true,
+        subtitle: "'휴학'일 경우 휴학 직전 학기를 선택해 주세요.",
+        subNodes: [
+          {
+            splitNumber: 4,
+            name: "grade",
+            require: true,
+            value: ["1학년", "2학년", "3학년", "4학년"],
+          },
+          {
+            splitNumber: 2,
+            name: "semester",
+            require: true,
+            value: ["1학기", "2학기"],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 3,
+    title: "기본 인적 사항을 입력해주세요.",
+    subtitle: "복수 전공과 부전공은 선택 입력사항입니다.",
+    direction: "horizontal",
+    require: false,
+    nodes: [
+      {
+        type: "text",
+        name: "major",
+        title: "전공",
+        require: true,
+        errorMessages: "전공을 입력해주세요.",
+      },
+      {
+        type: "text",
+        name: "doubleMajor",
+        title: "복수전공",
+        require: false,
+      },
+      {
+        type: "text",
+        name: "minor",
+        title: "부전공",
+        require: false,
+      },
+    ],
+  },
+  {
+    id: 4,
+    title: "기타 질문 사항에 답변해주세요.",
+    direction: "horizontal",
+    require: true,
+    nodes: [
+      {
+        name: "activity",
+        require: true,
+        type: "text",
+        title:
+          "학업 외에 병행하고 있거나 향후 계획 중에 있는 활동이 있으시다면 서술해 주세요.",
+        subtitle:
+          "(동아리, 연구실, 아르바이트, 스터디, 교환학생 등), 없을 경우, 없음으로 기재해 주세요.",
+      },
+      {
+        name: "channel",
+        require: true,
+        type: "checkboxWithEtc",
+        title: "지원 경로(중복 선택 가능)",
+        value: [
+          "학과 공지사항",
+          "홍보 포스터 / 현수막",
+          "지인 소개",
+          "인스타그램",
+          "페이스북",
+          "에브리타임",
+        ],
+        errorMessages: "지원 경로를 선택해주세요.",
+      },
+    ],
+  },
+];
+
+export const APPLICATION_NAVBAR = [
+  { id: 1, title: "프로젝트 희망 분야를 선택해주세요." },
+  { id: 2, title: "기본 인적 사항을 입력해주세요." },
+  { id: 3, title: "기본 인적 사항을 입력해주세요." },
+  { id: 4, title: "기타 질문 사항에 답변해주세요." },
+];
+
+export const APPLICATION_TIMELINE: ApplicationTimeline = {
+  seperate: 30,
+  time: [
+    {
+      startTime: new Date(2024, 9, 23, 10, 0, 0),
+      endTime: new Date(2024, 9, 23, 21, 0, 0),
+    },
+    {
+      startTime: new Date(2024, 9, 24, 10, 0, 0),
+      endTime: new Date(2024, 9, 24, 21, 0, 0),
+    },
+    {
+      startTime: new Date(2024, 9, 25, 10, 0, 0),
+      endTime: new Date(2024, 9, 25, 21, 0, 0),
+    },
+  ],
+  disableTime: [],
+};
+
+export const END_DATE = {
+  month: 3,
+  date: 18,
+};
+
+export const FINAL_DATE = {
+  year: 2024,
+  month: 3,
+  date: 25,
+};

--- a/frontend/src/constants/application/28/designer.ts
+++ b/frontend/src/constants/application/28/designer.ts
@@ -1,0 +1,283 @@
+import type { ApplicationQuestion } from "../type";
+
+export const APPLICATION_DESIGN: ApplicationQuestion[] = [
+  {
+    id: 5,
+    title: "자기소개 및 에코노베이션에 지원하게 된 계기를 서술해 주세요.",
+    direction: "horizontal",
+    require: true,
+    nodes: [
+      {
+        name: "reason",
+        require: true,
+        type: "textarea",
+        errorMessages: "에코노베이션에 지원하게 된 계기를 입력해주세요.",
+      },
+    ],
+  },
+  {
+    id: 6,
+    title: "본인이 계획하고 있는 진로가 무엇인가요?",
+    subtitle: "IT 분야가 아니어도 괜찮습니다",
+    direction: "horizontal",
+    require: true,
+    nodes: [
+      {
+        name: "future",
+        require: true,
+        type: "textarea",
+        errorMessages: "디자이너를 희망하는 이유를 입력해주세요.",
+      },
+    ],
+  },
+  {
+    id: 7,
+    title:
+      "UI/UX 디자인 작업물들 중 가장 자신 있는 디자인 작업물을 설명하고, 이를 통해 배우게 된 점이 있다면 서술해 주세요.",
+    direction: "horizontal",
+    nodes: [
+      {
+        name: "workDescript",
+        require: true,
+        type: "textarea",
+        errorMessages: "디자인 작업물을 설명해주세요.",
+      },
+    ],
+    require: true,
+  },
+  {
+    id: 8,
+    title:
+      "UI/UX 디자인을 할 때, 가장 중요한 것은 무엇이라고 생각하나요? 한가지 키워드를 중심으로 서술해주세요.",
+    direction: "horizontal",
+    nodes: [
+      {
+        name: "keyword",
+        require: true,
+        type: "textarea",
+        errorMessages: "가장 중요한 것을 서술해 주세요.",
+      },
+    ],
+    require: true,
+  },
+  {
+    id: 9,
+    title:
+      "우리 주변의 IT 서비스 중에 UI/UX를 개선하고 싶은 서비스가 있다면, 어떤 점을 '왜' 그리고 '어떻게' 개선하고 싶은지 서술해 주세요.",
+    direction: "horizontal",
+    nodes: [
+      {
+        name: "betterment",
+        require: true,
+        type: "textarea",
+        errorMessages: "개선하고 싶은 서비스를 서술해주세요.",
+      },
+    ],
+  },
+  {
+    id: 10,
+    title:
+      "어떤 일에 도전하고 실패해 본 경험이 있나요? 그 실패를 어떻게 극복했는지 서술해 주세요.",
+    subtitle: "소프트웨어 분야 관련 경험이 아니어도 좋습니다.",
+    direction: "horizontal",
+    nodes: [
+      {
+        name: "failure",
+        require: true,
+        type: "textarea",
+        errorMessages: "협업에 있어서 중요하다고 생각되는 것을 입력해주세요.",
+      },
+    ],
+  },
+  {
+    id: 11,
+    title:
+      "무언가에 깊게 빠지거나 파고 들어본 적이 있나요? 좋아하는 것을 위해서 주변에서 인정할 정도로 깊게 빠져본 적이 있다면 서술해 주세요.",
+    subtitle: "소프트웨어 분야 관련 경험이 아니어도 좋습니다.",
+    direction: "horizontal",
+    nodes: [
+      {
+        name: "drain",
+        require: true,
+        type: "textarea",
+        errorMessages: "깊게 빠져본 경험을 입력해주세요.",
+      },
+    ],
+  },
+  {
+    id: 12,
+    title:
+      "협업(프로젝트, 팀 활동)에 있어서 가장 중요하다고 생각되는 것은 무엇인지 그 이유와 함께 지원자님의 생각을 서술해 주세요.",
+    direction: "horizontal",
+    nodes: [
+      {
+        name: "collaboration",
+        require: true,
+        type: "textarea",
+        errorMessages: "협업에 있어서 중요하다고 생각되는 것을 입력해주세요.",
+      },
+    ],
+  },
+  {
+    id: 13,
+    title:
+      "에코노베이션에 최종 합격 시 신입 기수로 구성된 팀으로 개발 프로젝트에 참여하고, 목표를 달성하기 위해 스스로 끊임없이 배우고 노력합니다. 에코노베이션에 들어오게 된다면 어떤 목표와 학습 계획을 바탕으로 활동하고 싶나요?",
+    direction: "horizontal",
+    nodes: [
+      {
+        name: "studyPlan",
+        require: true,
+        type: "textarea",
+        errorMessages: "목표와 학습 계획을 입력해주세요.",
+      },
+    ],
+  },
+  {
+    id: 14,
+    title: "자신을 어필할 수 있는 포트폴리오를 업로드해 주세요.",
+    direction: "horizontal",
+    subtitle:
+      "지원자 분의 포트폴리오 링크 접근 권한을 열어주세요. 만약 접근 권한이 없을 경우 불이익이 있을 수 있습니다.",
+    nodes: [
+      {
+        name: "portfolio",
+        require: false,
+        type: "text",
+        title: "참고 URL",
+        subtitle: "Github, Blog, Notion, Website 등",
+      },
+      {
+        name: "fileUrl",
+        require: true,
+        type: "text",
+        title: "파일 URL",
+        subtitle: "Google Drive 등",
+      },
+    ],
+  },
+  {
+    id: -1,
+    title: "개인정보 수집에 관한 안내 및 개인정보 수집",
+    direction: "vertical",
+    nodes: [
+      {
+        id: 15,
+        direction: "horizontal",
+        title: "합격여부 전달을 위하여 이메일을 입력해주세요.",
+        subtitle: "이메일을 기재하지 않을 시, 합격이 취소될 수 있습니다.",
+        require: true,
+        nodes: [
+          {
+            type: "text",
+            name: "email",
+            title: "E-mail",
+            validate: "emailString",
+            errorMessages: "이메일을 입력해주세요.",
+            require: true,
+          },
+        ],
+      },
+      {
+        id: 16,
+        direction: "horizontal",
+        title:
+          "에코노베이션은 3학기 이상의 활동을 권장하고 있으며 매주 금요일 17시에는 주간발표가 있습니다.\n위 내용을 확인하셨으면 '확인했습니다'를 기입해주세요.",
+        require: true,
+        nodes: [
+          {
+            type: "text",
+            name: "check",
+            validate: "confirmationString",
+            errorMessages: '"확인했습니다"를 입력해주세요.',
+            require: true,
+          },
+        ],
+      },
+      {
+        id: 17,
+        direction: "radioForCheck",
+        title:
+          "개인정보 수집에 관한 안내 및 개인정보 수집에 대한 안내에 동의하시나요?",
+        require: true,
+        nodes: [
+          {
+            type: "radioForCheck",
+            name: "personalInformationAgree",
+            title: "개인정보 수집(공통)에 대한 안내",
+            value: ["동의합니다.", "동의하지 않습니다."],
+            require: true,
+          },
+          {
+            type: "radioForCheck",
+            name: "personalInformationAgreeForPortfolio",
+            title: "개인정보 수집(포트폴리오)에 대한 안내",
+            value: ["동의합니다.", "동의하지 않습니다."],
+            require: true,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 18,
+    title: "면접 가능시간을 선택해주세요.(중복 선택 가능)",
+    subtitle:
+      "면접은 오프라인으로 진행되며 지원서에 작성된 내용을 토대로 약 10분간 진행될 예정입니다.\n선택한 시간이 적을 경우, 지원자님의 면접이 임의 시간에 배정될 수 있습니다.\n면접이 가능한 시간대를 모두 선택해 주시기 바랍니다.",
+    direction: "timeline",
+    require: false,
+    nodes: [
+      {
+        type: "timeline",
+        name: "timeline",
+        require: true,
+      },
+    ],
+  },
+];
+
+export const APPLICATION_NAVBAR_DESIGN = [
+  {
+    id: 5,
+    title: "자기소개 및 에코노베이션에 지원하게 된 계기를 서술해 주세요.",
+  },
+  {
+    id: 6,
+    title: "본인이 계획하고 있는 진로가 무엇인가요?",
+  },
+  {
+    id: 7,
+    title:
+      "UI/UX 디자인 작업물들 중 가장 자신 있는 디자인 작업물을 설명하고, 이를 통해 배우게 된 점이 있다면 서술해 주세요.",
+  },
+  {
+    id: 8,
+    title:
+      "UI/UX 디자인을 할 때, 가장 중요한 것은 무엇이라고 생각하나요? 한가지 키워드를 중심으로 서술해 주세요.",
+  },
+  {
+    id: 9,
+    title:
+      "IT 서비스 중에 개선하고 싶은 서비스가 있다면, '왜', '어떻게' 개선하고 싶은지 서술해 주세요.",
+  },
+  {
+    id: 10,
+    title: "어떤 일에 도전하고 실패해 본 경험이 있나요?",
+  },
+  {
+    id: 11,
+    title: "무언가에 깊게 빠지거나 파고 들어본 적이 있나요?",
+  },
+  {
+    id: 12,
+    title:
+      "협업(프로젝트, 팀 활동)에 있어서 가장 중요하다고 생각되는 것은 무엇인지 그 이유와 함께 서술해주세요. ",
+  },
+  {
+    id: 13,
+    title:
+      "에코노베이션에 들어오게 된다면 어떤 목표와 학습 계획을 바탕으로 활동하고 싶나요?",
+  },
+  { id: 14, title: "자신을 어필할 수 있는 포트폴리오를 업로드해주세요." },
+  { id: 15, title: "개인정보 수집에 관한 안내 및 개인정보 수집" },
+  { id: 16, title: "면접 가능시간을 선택해주세요.(중복 선택 가능)" },
+];

--- a/frontend/src/constants/application/28/developer.ts
+++ b/frontend/src/constants/application/28/developer.ts
@@ -1,0 +1,260 @@
+import type { ApplicationQuestion } from "../type";
+
+export const APPLICATION_DEVELOPER: ApplicationQuestion[] = [
+  {
+    id: 5,
+    title: "자기소개 및 에코노베이션에 지원하게 된 계기를 서술해 주세요.",
+    direction: "horizontal",
+    require: true,
+    nodes: [
+      {
+        name: "reason",
+        require: true,
+        type: "textarea",
+        errorMessages: "에코노베이션에 지원하게 된 계기를 입력해주세요.",
+      },
+    ],
+  },
+  {
+    id: 6,
+    title: "개발자를 희망하는 이유는 무엇인가요?",
+    subtitle: "계획하고 계신 진로와 이를 위해 노력한 내용을 말씀해 주세요.",
+    direction: "horizontal",
+    require: true,
+    nodes: [
+      {
+        name: "future",
+        require: true,
+        type: "textarea",
+        errorMessages: "개발자를 희망하는 이유를 입력해주세요.",
+      },
+    ],
+  },
+  {
+    id: 7,
+    title:
+      "소프트웨어 프로젝트에서 주도적으로 개발한 경험이 있나요?(캡스톤 디자인 제외)",
+    direction: "booleanTextarea",
+    require: true,
+    nodes: [
+      {
+        name: "experience",
+        require: true,
+        value: ["있다", "없다"],
+        type: "booleanTextarea",
+        subNodes: [
+          {
+            name: "experienceTextarea",
+            title:
+              "본인이 어떤 역할을 했고, 그 경험을 통해 무엇을 얻었는지 서술해 주세요.",
+            require: true,
+            type: "true",
+          },
+          {
+            name: "experienceTextarea",
+            title:
+              "앞으로 해보고 싶은 프로젝트가 무엇인가요? 그 이유와 함께 서술해 주세요.",
+            require: true,
+            type: "false",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 8,
+    title:
+      "어떤 일에 도전하고 실패해 본 경험이 있나요? 그 실패를 어떻게 극복했는지 서술해 주세요.",
+    subtitle: "소프트웨어 관련 경험이 아니어도 좋습니다",
+    direction: "horizontal",
+    nodes: [
+      {
+        name: "restoration",
+        require: true,
+        type: "textarea",
+        errorMessages: "도전하고 실패해 본 경험을 입력해주세요.",
+      },
+    ],
+    require: true,
+  },
+  {
+    id: 9,
+    title:
+      "무언가에 깊게 빠지거나 파고 들어본 적이 있나요? 좋아하는 것을 위해서 주변에서 인정할 정도로 깊게  빠져본 적이 있다면 서술해주세요.",
+    subtitle: "소프트웨어 분야 관련 경험이 아니어도 좋습니다.",
+    direction: "horizontal",
+    require: true,
+    nodes: [
+      {
+        name: "deep",
+        require: true,
+        type: "textarea",
+        errorMessages: "깊게 빠져본 경험을 입력해주세요.",
+      },
+    ],
+  },
+  {
+    id: 10,
+    title:
+      "협업(프로젝트, 팀 활동)에 있어서 가장 중요하다고 생각되는 것은 무엇인지 그 이유와 함께 지원자님의 생각을 서술해 주세요.",
+    direction: "horizontal",
+    require: true,
+    nodes: [
+      {
+        name: "collaboration",
+        require: true,
+        type: "textarea",
+        errorMessages: "협업에 있어서 중요하다고 생각되는 것을 입력해주세요.",
+      },
+    ],
+  },
+  {
+    id: 11,
+    title:
+      "에코노베이션에 최종 합격 시 신입 기수로 구성된 팀으로 개발 프로젝트에 참여하고, 목표를 달성하기 위해 스스로 끊임없이 배우고 노력합니다. 에코노베이션에 들어오게 된다면 어떤 목표와 학습 계획을 바탕으로 활동하고 싶나요?",
+    direction: "horizontal",
+    require: true,
+    nodes: [
+      {
+        name: "studyPlan",
+        require: true,
+        type: "textarea",
+        errorMessages: "목표와 학습 계획을 입력해주세요.",
+      },
+    ],
+  },
+  {
+    id: 12,
+    title: "자신을 어필할 수 있는 포트폴리오를 업로드해 주세요.",
+    subtitle:
+      "지원자 분의 포트폴리오 링크 접근 권한을 열어주세요. 만약 접근 권한이 없을 경우 불이익이 있을 수 있습니다.",
+    direction: "horizontal",
+    nodes: [
+      {
+        name: "portfolio",
+        require: false,
+        type: "text",
+        title: "참고 URL",
+        subtitle: "Github, Blog, Notion, Website 등",
+      },
+      {
+        name: "fileUrl",
+        require: false,
+        type: "text",
+        title: "파일 URL",
+        subtitle: "Google Drive 등",
+      },
+    ],
+  },
+  {
+    id: -1,
+    title: "개인정보 수집에 관한 안내 및 개인정보 수집",
+    direction: "vertical",
+    nodes: [
+      {
+        id: 13,
+        direction: "horizontal",
+        title: "합격여부 전달을 위하여 이메일을 입력해주세요.",
+        subtitle: "이메일을 기재하지 않을 시, 합격이 취소될 수 있습니다.",
+        require: true,
+        nodes: [
+          {
+            type: "text",
+            name: "email",
+            title: "E-mail",
+            validate: "emailString",
+            errorMessages: "이메일을 입력해주세요.",
+            require: true,
+          },
+        ],
+      },
+      {
+        id: 14,
+        direction: "horizontal",
+        title:
+          "에코노베이션은 3학기 이상의 활동을 권장하고 있으며 매주 금요일 17시에는 주간발표가 있습니다.\n위 내용을 확인하셨으면 '확인했습니다'를 기입해주세요.",
+        require: true,
+        nodes: [
+          {
+            type: "text",
+            name: "check",
+            validate: "confirmationString",
+            errorMessages: '"확인했습니다"를 입력해주세요.',
+            require: true,
+          },
+        ],
+      },
+      {
+        id: 15,
+        direction: "radioForCheck",
+        title:
+          "개인정보 수집에 관한 안내 및 개인정보 수집에 대한 안내에 동의하시나요?",
+        require: true,
+        nodes: [
+          {
+            type: "radioForCheck",
+            name: "personalInformationAgree",
+            title: "개인정보 수집(공통)에 대한 안내",
+            value: ["동의합니다.", "동의하지 않습니다."],
+            require: true,
+          },
+          {
+            type: "radioForCheck",
+            name: "personalInformationAgreeForPortfolio",
+            title: "개인정보 수집(포트폴리오)에 대한 안내",
+            value: ["동의합니다.", "동의하지 않습니다."],
+            require: true,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 16,
+    title: "면접 가능시간을 선택해주세요.(중복 선택 가능)",
+    subtitle:
+      "면접은 오프라인으로 진행되며 지원서에 작성된 내용을 토대로 약 10분간 진행될 예정입니다.\n선택한 시간이 적을 경우, 지원자님의 면접이 임의 시간에 배정될 수 있습니다.\n면접이 가능한 시간대를 모두 선택해 주시기 바랍니다.",
+    direction: "timeline",
+    require: true,
+    nodes: [
+      {
+        type: "timeline",
+        name: "timeline",
+        require: true,
+      },
+    ],
+  },
+];
+
+export const APPLICATION_NAVBAR_DEVELOPER = [
+  {
+    id: 5,
+    title: "자기소개 및 에코노베이션에 지원하게 된 계기를 서술해 주세요.",
+  },
+  {
+    id: 6,
+    title: "개발자를 희망하는 이유는 무엇인가요?",
+  },
+  {
+    id: 7,
+    title: "소프트웨어 프로젝트에서 주도적으로 개발한 경험이 있나요?",
+  },
+  {
+    id: 8,
+    title: "어떤 일에 도전하고 실패해 본 경험이 있나요?",
+  },
+  { id: 9, title: "무언가에 깊게 빠지거나 파고 들어본 적이 있나요?" },
+  {
+    id: 10,
+    title:
+      "협업(프로젝트, 팀 활동)에 있어서 가장 중요하다고 생각되는 것은 무엇인지 서술해 주세요.",
+  },
+  {
+    id: 11,
+    title:
+      "에코노베이션에 들어오게 된다면 어떤 목표와 학습 계획을 바탕으로 활동하고 싶나요?",
+  },
+  { id: 12, title: "자신을 어필할 수 있는 포트폴리오를 업로드해주세요." },
+  { id: 13, title: "개인정보 수집에 관한 안내 및 개인정보 수집" },
+  { id: 14, title: "면접 가능시간을 선택해주세요.(중복 선택 가능)" },
+];

--- a/frontend/src/constants/application/28/manager.ts
+++ b/frontend/src/constants/application/28/manager.ts
@@ -1,0 +1,298 @@
+import type { ApplicationQuestion } from "../type";
+
+export const APPLICATION_MANAGER: ApplicationQuestion[] = [
+  {
+    id: 5,
+    title: "자기소개 및 에코노베이션에 지원하게 된 계기를 서술해 주세요.",
+    direction: "horizontal",
+    require: true,
+    nodes: [
+      {
+        name: "reason",
+        require: true,
+        type: "textarea",
+        errorMessages: "에코노베이션에 지원하게 된 계기를 입력해주세요.",
+      },
+    ],
+  },
+  {
+    id: 6,
+    title: "본인이 계획하고 있는 진로가 무엇인가요?",
+    subtitle: "IT 분야가 아니어도 괜찮습니다.",
+    direction: "horizontal",
+    require: true,
+    nodes: [
+      {
+        name: "future",
+        require: true,
+        type: "textarea",
+        errorMessages: "진로가 무엇인지 입력해주세요.",
+      },
+    ],
+  },
+  {
+    id: 7,
+    title:
+      "PM(기획자)은 아이디어를 낼 뿐만 아니라, 자신의 아이디어를 동료들이 이해할 수 있는 형식으로 효과적으로 전달해야 하는 역할입니다. 지원자님께서 자신의 아이디어를 시각적으로 구현하여, 구체적으로 전달한 경험이 있다면 서술해 주세요.",
+    subtitle:
+      "어떤 아이디어를 어떤 형태로 구현하여, 누구에게 전달했는지 잘 드러나도록 작성해 주세요.",
+    direction: "horizontal",
+    nodes: [
+      {
+        name: "communication",
+        require: true,
+        type: "textarea",
+        errorMessages: "아이디어를 구체적으로 전달한 경험을 입력해주세요.",
+      },
+    ],
+    require: true,
+  },
+  {
+    id: 8,
+    title:
+      "지원자님께서 직접 IT 서비스(UI/UX)를 설계하거나 개선한 경험이 있나요?(캡스톤 디자인 제외)",
+    direction: "booleanTextarea",
+    require: true,
+    nodes: [
+      {
+        name: "experience",
+        require: true,
+        value: ["있다", "없다"],
+        type: "booleanTextarea",
+        subNodes: [
+          {
+            name: "experienceTextarea",
+            title:
+              "본인이 어떠한 부분을 설계 및 개선했고, 그 경험을 통해 무엇을 얻었는지 서술해 주세요.",
+            require: true,
+            type: "true",
+          },
+          {
+            name: "experienceTextarea",
+            title:
+              "우리 주변의 IT서비스 중에 개선하고 싶은 서비스가 있다면, 어떤 점을 '왜' 그리고 '어떻게' 개선하고 싶은지 서술해 주세요.",
+            require: true,
+            type: "false",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 9,
+    title:
+      "어떤 일에 도전하고 실패해 본 경험이 있나요? 그 실패를 어떻게 극복했는지 서술해 주세요.",
+    subtitle: "소프트웨어 분야 관련 경험이 아니어도 좋습니다.",
+    direction: "horizontal",
+    nodes: [
+      {
+        name: "failual",
+        require: true,
+        type: "textarea",
+        errorMessages: "도전하고 실패해 본 경험을 입력해주세요.",
+      },
+    ],
+    require: true,
+  },
+  {
+    id: 10,
+    title:
+      "무언가에 깊게 빠지거나 파고 들어본 적이 있나요? 좋아하는 것을 위해서 주변에서 인정할 정도로 깊게 빠져본 적이 있다면 서술해 주세요.",
+    subtitle: "소프트웨어 분야 관련 경험이 아니어도 좋습니다.",
+    direction: "horizontal",
+    nodes: [
+      {
+        name: "deep",
+        require: true,
+        type: "textarea",
+        errorMessages: "깊게 빠져본 경험을 입력해주세요.",
+      },
+    ],
+    require: true,
+  },
+  {
+    id: 11,
+    title:
+      "협업(프로젝트, 팀 활동)에 있어서 가장 중요하다고 생각되는 것은 무엇인지 그 이유와 함께 지원자님의 생각을 서술해 주세요.",
+    direction: "horizontal",
+    nodes: [
+      {
+        name: "collaboration",
+        require: true,
+        type: "textarea",
+        errorMessages: "협업에 있어서 중요하다고 생각되는 것을 입력해주세요.",
+      },
+    ],
+    require: true,
+  },
+  {
+    id: 12,
+    title:
+      "에코노베이션에 최종 합격 시 신입 기수로 구성된 팀으로 개발 프로젝트에 참여하고, 목표를 달성하기 위해 스스로 끊임없이 배우고 노력합니다. 에코노베이션에 들어오게 된다면 어떤 목표와 학습 계획을 바탕으로 활동하고 싶나요?",
+    direction: "horizontal",
+    nodes: [
+      {
+        name: "studyPlan",
+        require: true,
+        type: "textarea",
+        errorMessages: "목표와 학습 계획을 입력해주세요.",
+      },
+    ],
+    require: true,
+  },
+  {
+    id: 13,
+    title: "자신을 어필할 수 있는 포트폴리오를 업로드해 주세요.",
+    subtitle:
+      "지원자 분의 포트폴리오 링크 접근 권한을 열어주세요. 만약 접근 권한이 없을 경우 불이익이 있을 수 있습니다.",
+    direction: "horizontal",
+    nodes: [
+      {
+        name: "portfolio",
+        require: false,
+        type: "text",
+        title: "참고 URL",
+        subtitle: "Github, Blog, Notion, Website 등",
+      },
+      {
+        name: "fileUrl",
+        require: false,
+        type: "text",
+        title: "파일 URL",
+        subtitle: "Google Drive 등",
+      },
+      {
+        type: "bar",
+      },
+      {
+        type: "justText",
+        title:
+          "기획자를 지원하는 경우 이번 학기에 진행하고 싶은 프로젝트의 기획서를 제출해 주세요.",
+        subtitle:
+          "단, 제출한 기획을 기반으로 이번 학기에 프로젝트를 진행하지 못할 수 있습니다.",
+      },
+      {
+        name: "fileUrlforPlanner",
+        require: true,
+        type: "text",
+        title: "파일 URL",
+        subtitle: "Google Drive 등",
+      },
+    ],
+    require: false,
+  },
+  {
+    id: -1,
+    title: "개인정보 수집에 관한 안내 및 개인정보 수집",
+    direction: "vertical",
+    nodes: [
+      {
+        id: 14,
+        direction: "horizontal",
+        title: "합격여부 전달을 위하여 이메일을 입력해주세요.",
+        subtitle: "이메일을 기재하지 않을 시, 합격이 취소될 수 있습니다.",
+        require: true,
+        nodes: [
+          {
+            type: "text",
+            name: "email",
+            title: "E-mail",
+            validate: "emailString",
+            errorMessages: "이메일을 입력해주세요.",
+            require: true,
+          },
+        ],
+      },
+      {
+        id: 15,
+        direction: "horizontal",
+        title:
+          "에코노베이션은 3학기 이상의 활동을 권장하고 있으며 매주 금요일 17시에는 주간발표가 있습니다.\n위 내용을 확인하셨으면 '확인했습니다'를 기입해주세요.",
+        require: true,
+        nodes: [
+          {
+            type: "text",
+            name: "check",
+            validate: "confirmationString",
+            errorMessages: '"확인했습니다"를 입력해주세요.',
+            require: true,
+          },
+        ],
+      },
+      {
+        id: 16,
+        direction: "radioForCheck",
+        title:
+          "개인정보 수집에 관한 안내 및 개인정보 수집에 대한 안내에 동의하시나요?",
+        require: true,
+        nodes: [
+          {
+            type: "radioForCheck",
+            name: "personalInformationAgree",
+            title: "개인정보 수집(공통)에 대한 안내",
+            value: ["동의합니다.", "동의하지 않습니다."],
+            require: true,
+          },
+          {
+            type: "radioForCheck",
+            name: "personalInformationAgreeForPortfolio",
+            title: "개인정보 수집(포트폴리오)에 대한 안내",
+            value: ["동의합니다.", "동의하지 않습니다."],
+            require: true,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 17,
+    title: "면접 가능시간을 선택해주세요.(중복 선택 가능)",
+    subtitle:
+      "면접은 오프라인으로 진행되며 지원서에 작성된 내용을 토대로 약 10분간 진행될 예정입니다.\n선택한 시간이 적을 경우, 지원자님의 면접이 임의 시간에 배정될 수 있습니다.\n면접이 가능한 시간대를 모두 선택해 주시기 바랍니다.",
+    direction: "timeline",
+    require: false,
+    nodes: [
+      {
+        type: "timeline",
+        name: "timeline",
+        require: true,
+      },
+    ],
+  },
+];
+
+export const APPLICATION_NAVBAR_MANAGER = [
+  { id: 5, title: "에코노베이션에 지원하게 된 계기는 무엇인가요?" },
+  {
+    id: 6,
+    title: "본인이 계획하고 있는 진로가 무엇인가요?",
+  },
+  {
+    id: 7,
+    title:
+      "지원자님께서 자신의 아이디어를 시각적으로 구현하여, 구체적으로 전달한 경험이 있다면 서술해 주세요.",
+  },
+  {
+    id: 8,
+    title:
+      "지원자님께서 직접 IT 서비스(UI/UX)를 설계하거나 개선한 경험이 있나요?",
+  },
+  { id: 9, title: "어떤 일에 도전하고 실패해 본 경험이 있나요?" },
+  {
+    id: 10,
+    title: "무언가 깊게 빠지거나 파고 들어본 적이 있나요?",
+  },
+  {
+    id: 11,
+    title:
+      "협업(프로젝트, 팀 활동)에 있어서 가장 중요하다고 생각되는 것은 무엇인지 서술해 주세요.",
+  },
+  {
+    id: 12,
+    title:
+      "에코노베이션에 들어오게 된다면 어떤 목표와 학습 계획을 바탕으로 활동하고 싶나요?",
+  },
+  { id: 13, title: "자신을 어필할 수 있는 포트폴리오를 업로드해주세요." },
+  { id: 14, title: "개인정보 수집에 관한 안내 및 개인정보 수집" },
+  { id: 15, title: "면접 가능시간을 선택해주세요.(중복 선택 가능)" },
+];

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -1,6 +1,4 @@
-export const CURRENT_GENERATION: number = +(
-  process.env.NEXT_PUBLIC_CURRENT_GENERATION ?? 0
-);
+export const CURRENT_GENERATION: number = 28;
 
 export const MAIN_MENU = [
   {

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -1,6 +1,4 @@
-import { CommonNavbarCellProps } from "@/components/common/navbar/NavbarCell";
-
-export const CURRENT_GENERATION: number = 28;
+export const CURRENT_GENERATION = 28;
 
 export const MAIN_MENU = [
   {
@@ -35,41 +33,55 @@ export const MAIN_MENU = [
   },
 ] as const;
 
-export const MainNavbar = (generation: number): CommonNavbarCellProps[] =>
-  [
-    {
-      title: "신입모집 신청 페이지",
-      short_title: "신청",
-      type: "apply",
-      target: "_blank",
-      href: `/application`,
-    },
-    {
-      title: "신입모집 칸반보드",
-      short_title: "칸반보드",
-      type: "kanban",
-      href: `/kanban/${generation}`,
-    },
-    {
-      title: "신입모집 면접 기록",
-      short_title: "면접기록",
-      type: "interview",
-      href: `/interview/${generation}`,
-    },
-    {
-      title: "신입모집 지원현황",
-      short_title: "지원현황",
-      type: "applicant",
-      href: `/applicant/${generation}`,
-    },
-    {
-      title: "신입모집 쉐어 포인트",
-      short_title: "쉐어포인트",
-      type: "sharepoint",
-      target: "_blank",
-      href: "https://ejnu.sharepoint.com/sites/msteams_bbf640/Shared%20Documents/Forms/AllItems.aspx?id=%2Fsites%2Fmsteams_bbf640%2FShared%20Documents%2F2023%EB%85%84%2F1%ED%95%99%EA%B8%B0%2F%EC%8B%A0%EC%9E%85%EB%AA%A8%EC%A7%91&p=true&ga=1",
-    },
-  ] as const;
+export interface NavbarItem {
+  title: string;
+  short_title: string;
+  type:
+    | "apply"
+    | "kanban"
+    | "interview"
+    | "applicant"
+    | "sharepoint"
+    | "admin"
+    | "toggle";
+  target?: "_blank" | "_self" | "_parent" | "_top";
+  href: string;
+}
+
+export const MainNavbar = (generation: number): NavbarItem[] => [
+  {
+    title: "신입모집 신청 페이지",
+    short_title: "신청",
+    type: "apply",
+    target: "_blank",
+    href: `/application`,
+  },
+  {
+    title: "신입모집 칸반보드",
+    short_title: "칸반보드",
+    type: "kanban",
+    href: `/kanban/${generation}`,
+  },
+  {
+    title: "신입모집 면접 기록",
+    short_title: "면접기록",
+    type: "interview",
+    href: `/interview/${generation}`,
+  },
+  {
+    title: "신입모집 지원현황",
+    short_title: "지원현황",
+    type: "applicant",
+    href: `/applicant/${generation}`,
+  },
+  {
+    title: "신입모집 쉐어 포인트",
+    short_title: "쉐어포인트",
+    type: "sharepoint",
+    target: "_blank",
+    href: "https://ejnu.sharepoint.com/sites/msteams_bbf640/Shared%20Documents/Forms/AllItems.aspx?id=%2Fsites%2Fmsteams_bbf640%2FShared%20Documents%2F2023%EB%85%84%2F1%ED%95%99%EA%B8%B0%2F%EC%8B%A0%EC%9E%85%EB%AA%A8%EC%A7%91&p=true&ga=1",
+  },
+];
 
 export const APPLICANT_KEYS = [
   "field",

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -1,4 +1,6 @@
-export const CURRENT_GENERATION = process.env.NEXT_PUBLIC_CURRENT_GENERATION;
+export const CURRENT_GENERATION: number = +(
+  process.env.NEXT_PUBLIC_CURRENT_GENERATION ?? 0
+);
 
 export const MAIN_MENU = [
   {
@@ -33,50 +35,44 @@ export const MAIN_MENU = [
   },
 ] as const;
 
-export const MainNavbar = [
-  {
-    title: "신입모집 신청 페이지",
-    short_title: "신청",
-    type: "apply",
-    target: "_blank",
-    href: `/application`,
-  },
-  {
-    title: "신입모집 칸반보드",
-    short_title: "칸반보드",
-    type: "kanban",
-    target: "none",
-    href: `/kanban/${CURRENT_GENERATION}`,
-  },
-  {
-    title: "신입모집 면접 기록",
-    short_title: "면접기록",
-    type: "interview",
-    target: "none",
-    href: `/interview/${CURRENT_GENERATION}`,
-  },
-  {
-    title: "신입모집 지원현황",
-    short_title: "지원현황",
-    type: "applicant",
-    target: "none",
-    href: `/applicant/${CURRENT_GENERATION}`,
-  },
-  {
-    title: "신입모집 쉐어 포인트",
-    short_title: "쉐어포인트",
-    type: "sharepoint",
-    target: "_blank",
-    href: "https://ejnu.sharepoint.com/sites/msteams_bbf640/Shared%20Documents/Forms/AllItems.aspx?id=%2Fsites%2Fmsteams_bbf640%2FShared%20Documents%2F2023%EB%85%84%2F1%ED%95%99%EA%B8%B0%2F%EC%8B%A0%EC%9E%85%EB%AA%A8%EC%A7%91&p=true&ga=1",
-  },
-  {
-    title: "지난 신입모집",
-    short_title: "지난 모집",
-    type: "history",
-    target: "_blank",
-    href: "https://trello.com/b/ioPTFCHN/2023-econovation-1%ED%95%99%EA%B8%B0-%EC%8B%A0%EC%9E%85%EB%AA%A8%EC%A7%91-tf%ED%8C%80",
-  },
-] as const;
+export const MainNavbar = (generation: number) =>
+  [
+    {
+      title: "신입모집 신청 페이지",
+      short_title: "신청",
+      type: "apply",
+      target: "_blank",
+      href: `/application`,
+    },
+    {
+      title: "신입모집 칸반보드",
+      short_title: "칸반보드",
+      type: "kanban",
+      target: "none",
+      href: `/kanban/${generation}`,
+    },
+    {
+      title: "신입모집 면접 기록",
+      short_title: "면접기록",
+      type: "interview",
+      target: "none",
+      href: `/interview/${generation}`,
+    },
+    {
+      title: "신입모집 지원현황",
+      short_title: "지원현황",
+      type: "applicant",
+      target: "none",
+      href: `/applicant/${generation}`,
+    },
+    {
+      title: "신입모집 쉐어 포인트",
+      short_title: "쉐어포인트",
+      type: "sharepoint",
+      target: "_blank",
+      href: "https://ejnu.sharepoint.com/sites/msteams_bbf640/Shared%20Documents/Forms/AllItems.aspx?id=%2Fsites%2Fmsteams_bbf640%2FShared%20Documents%2F2023%EB%85%84%2F1%ED%95%99%EA%B8%B0%2F%EC%8B%A0%EC%9E%85%EB%AA%A8%EC%A7%91&p=true&ga=1",
+    },
+  ] as const;
 
 export const APPLICANT_KEYS = [
   "field",

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -1,3 +1,5 @@
+import { CommonNavbarCellProps } from "@/components/common/navbar/NavbarCell";
+
 export const CURRENT_GENERATION: number = 28;
 
 export const MAIN_MENU = [
@@ -33,7 +35,7 @@ export const MAIN_MENU = [
   },
 ] as const;
 
-export const MainNavbar = (generation: number) =>
+export const MainNavbar = (generation: number): CommonNavbarCellProps[] =>
   [
     {
       title: "신입모집 신청 페이지",
@@ -46,21 +48,18 @@ export const MainNavbar = (generation: number) =>
       title: "신입모집 칸반보드",
       short_title: "칸반보드",
       type: "kanban",
-      target: "none",
       href: `/kanban/${generation}`,
     },
     {
       title: "신입모집 면접 기록",
       short_title: "면접기록",
       type: "interview",
-      target: "none",
       href: `/interview/${generation}`,
     },
     {
       title: "신입모집 지원현황",
       short_title: "지원현황",
       type: "applicant",
-      target: "none",
       href: `/applicant/${generation}`,
     },
     {

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -1,4 +1,4 @@
-export const CURRENT_GENERATION = 27;
+export const CURRENT_GENERATION = 28;
 
 export const MAIN_MENU = [
   {

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -1,4 +1,4 @@
-export const CURRENT_GENERATION = 28;
+export const CURRENT_GENERATION = process.env.NEXT_PUBLIC_CURRENT_GENERATION;
 
 export const MAIN_MENU = [
   {

--- a/frontend/src/hooks/useCreateQueryString.tsx
+++ b/frontend/src/hooks/useCreateQueryString.tsx
@@ -1,18 +1,14 @@
 import { useCallback } from "react";
 import { useSearchParams } from "next/navigation";
-
 export const useCreateQueryString = () => {
   const searchParams = useSearchParams();
-
   const createQueryString = useCallback(
     (name: string[], value: string[]) => {
       const params = new URLSearchParams(searchParams.toString());
       name.forEach((el, index) => params.set(el, value[index] || ""));
-
       return params.toString();
     },
     [searchParams]
   );
-
   return { createQueryString };
 };


### PR DESCRIPTION
## 주요 변경사항 

- 새로운 신입모집이 시작됨에 따라서 CURRENT_GENERATION 을 28로 업데이트 했습니다. 
- 이에 따라서 불러오는 상수 데이터를 저장하는 28.ts 및 기타 파일들을 추가하였습니다. 이는 27기의 파일과 동일하며, tf팀의 요청사항이 있을시 변경하도록 하겠습니다. 
- 추가적으로 navbar의 탭을 리팩토링 하였습니다
  - 기존 a 태그를 사용하여 전체 페이지를 리렌더링 하는 로직에서, Link 태그로 변경하여 next의 최적화 이점을 얻을 수 있도록 하였습니다.
  - 현재 url을 가져오는 로직이 최상위 로직에서 props로 필요한 곳까지 전달하는 로직을 해당 컴포넌트에서 `usePathname()` 을 사용하여 가져올 수 있도록 하였습니다. 

- 기존 칸반, 면접 기록, 지원 현황 페이지에서 각각 이동 방식이 [generation] 부분을 CURRENT_GENERATION에서 가져와 사용하던 부분을 현재 url에서 가져와 generation을 사용하는 방식으로 변경하여, 만약 이전 신입모집 기록을 볼 때 라우팅이 해당 신입모집 페이지만 볼 수 있도록 수정하였습니다. 
- 이전 신입모집을 바로 볼 수 있도록 네비게이션바에 이전 신입모집 보기 버튼을 추가하였습니다. 이는 url에서 가져온 generation값이 CURRENT_GENERATION과 동일한지를 확인 후 이전 신입모집 보기 혹은 현재 신입모집 보기 버튼으로 분기처리하도록 하였습니다. 

### 네브바 최적화
기존에 매번 전체 회면이 새롭게 렌더링 되던 부분을 변경된 부분만 렌더링 되도록 수정하였습니다
![최적화](https://github.com/user-attachments/assets/8464fcdb-71ec-4a8a-8b8d-21966816b3ea)


### 이전 신입모집 보기
![토글](https://github.com/user-attachments/assets/1dd05497-ab15-4e54-a2ae-8991b199af7d)



## 리뷰어에게...

## 관련 이슈

closes #156 

