### PR TITLE
test: 두번째 기본 인적 사항 테스트 코드 작성

### DIFF
--- a/frontend/cypress/e2e/application.second-personal-information.cy.ts
+++ b/frontend/cypress/e2e/application.second-personal-information.cy.ts
@@ -32,4 +32,16 @@ describe("2번째 인적사항 e2e 테스트", () => {
       ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
     ).click();
   });
+
+  it("전공, 복수전공, 부전공 입력 후 다음 버튼 클릭", () => {
+    cy.goSecondPersonalInformation();
+    cy.get("input.my-2.border.rounded-lg.p-4.w-full")
+      .eq(0)
+      .type("컴퓨터정보통신공학과");
+    cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(1).type("건축학과");
+    cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(2).type("물리학과");
+    cy.get(
+      ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
+    ).click();
+  });
 });

--- a/frontend/cypress/e2e/application.second-personal-information.cy.ts
+++ b/frontend/cypress/e2e/application.second-personal-information.cy.ts
@@ -1,3 +1,13 @@
 describe("2번째 인적사항 e2e 테스트", () => {
   beforeEach(() => cy.viewport(1200, 900));
+
+  it("전공 입력 후 다음 버튼 클릭", () => {
+    cy.goSecondPersonalInformation();
+    cy.get("input.my-2.border.rounded-lg.p-4.w-full")
+      .eq(0)
+      .type("컴퓨터정보통신공학과");
+    cy.get(
+      ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
+    ).click();
+  });
 });

--- a/frontend/cypress/e2e/application.second-personal-information.cy.ts
+++ b/frontend/cypress/e2e/application.second-personal-information.cy.ts
@@ -10,4 +10,15 @@ describe("2번째 인적사항 e2e 테스트", () => {
       ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
     ).click();
   });
+
+  it("전공, 복수전공 입력 후 다음 버튼 클릭", () => {
+    cy.goSecondPersonalInformation();
+    cy.get("input.my-2.border.rounded-lg.p-4.w-full")
+      .eq(0)
+      .type("컴퓨터정보통신공학과");
+    cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(1).type("물리학과");
+    cy.get(
+      ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
+    ).click();
+  });
 });

--- a/frontend/cypress/e2e/application.second-personal-information.cy.ts
+++ b/frontend/cypress/e2e/application.second-personal-information.cy.ts
@@ -21,4 +21,15 @@ describe("2번째 인적사항 e2e 테스트", () => {
       ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
     ).click();
   });
+
+  it("전공, 부전공 입력 후 다음 버튼 클릭", () => {
+    cy.goSecondPersonalInformation();
+    cy.get("input.my-2.border.rounded-lg.p-4.w-full")
+      .eq(0)
+      .type("컴퓨터정보통신공학과");
+    cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(2).type("물리학과");
+    cy.get(
+      ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
+    ).click();
+  });
 });

--- a/frontend/cypress/e2e/application.second-personal-information.cy.ts
+++ b/frontend/cypress/e2e/application.second-personal-information.cy.ts
@@ -1,0 +1,3 @@
+describe("2번째 인적사항 e2e 테스트", () => {
+  beforeEach(() => cy.viewport(1200, 900));
+});

--- a/frontend/cypress/e2e/application.second-personal-information.cy.ts
+++ b/frontend/cypress/e2e/application.second-personal-information.cy.ts
@@ -54,4 +54,16 @@ describe("2번째 인적사항 e2e 테스트", () => {
       console.log("Alert message:", text);
     });
   });
+
+  it("전공을 입력하지 않고 복수전공, 부전공을 입력 후 버튼 클릭", () => {
+    cy.goSecondPersonalInformation();
+    cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(1).type("건축학과");
+    cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(2).type("물리학과");
+    cy.get(
+      ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
+    ).click();
+    cy.on("window:alert", (text) => {
+      console.log("Alert message:", text);
+    });
+  });
 });

--- a/frontend/cypress/e2e/application.second-personal-information.cy.ts
+++ b/frontend/cypress/e2e/application.second-personal-information.cy.ts
@@ -44,4 +44,14 @@ describe("2번째 인적사항 e2e 테스트", () => {
       ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
     ).click();
   });
+
+  it("아무것도 입력하지 않고 다음 버튼 클릭", () => {
+    cy.goSecondPersonalInformation();
+    cy.get(
+      ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
+    ).click();
+    cy.on("window:alert", (text) => {
+      console.log("Alert message:", text);
+    });
+  });
 });

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -1,37 +1,24 @@
-/// <reference types="cypress" />
-// ***********************************************
-// This example commands.ts shows you how to
-// create various custom commands and overwrite
-// existing commands.
-//
-// For more comprehensive examples of custom
-// commands please read more here:
-// https://on.cypress.io/custom-commands
-// ***********************************************
-//
-//
-// -- This is a parent command --
-// Cypress.Commands.add('login', (email, password) => { ... })
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This will overwrite an existing command --
-// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
-//
-// declare global {
-//   namespace Cypress {
-//     interface Chainable {
-//       login(email: string, password: string): Chainable<void>
-//       drag(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
-//       dismiss(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
-//       visit(originalFn: CommandOriginalFn, url: string, options: Partial<VisitOptions>): Chainable<Element>
-//     }
-//   }
-// }
+declare namespace Cypress {
+  interface Chainable {
+    goSecondPersonalInformation(): Chainable<void>;
+  }
+}
+
+Cypress.Commands.add("goSecondPersonalInformation", () => {
+  cy.visit("http://localhost:3000/application");
+  cy.get('[for=":R7dmlllkq:"]').click();
+  cy.get('[for=":Rblmlllkq:"]').click();
+  cy.get('[for=":r1:"]').click();
+  cy.get(
+    ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
+  ).click(); // 첫번째 인적사항 페이지로 이동
+  cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(0).type("심민보");
+  cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(1).type("01000000000");
+  cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(2).type("111111");
+  cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(3).type("재학");
+  cy.get('[for=":rb:"]').click();
+  cy.get('[for=":re:"]').click();
+  cy.get(
+    ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
+  ).click(); // 두번째 인적사항 페이지로 이동
+});


### PR DESCRIPTION
## 주요 변경사항
- 두번째 인적사항 페이지로 이동하는 함수 구현

- 테스트 코드 구현
1. 전공 입력 + 다음 버튼 클릭
2. 전공 입력 + 복수 전공 입력 + 다음 버튼 클릭
3. 전공 입력 + 부전공 입력 + 다음 버튼 클릭
4. 전공 입력 + 복수 전공 입력 + 부전공 입력 + 다음 버튼 클릭
5. 아무것도 입력 x + 다음 버튼 클릭
6. 전공 입력 x + 복수 전공 입력 + 부전공 입력 + 다음 버튼 클릭
## 리뷰어에게...
cypress 에서는 alert 창이 뜨지 않기 때문에 alert 창을 감지해서 console문으로 내용을 출력해주었습니다 !

## 관련 이슈

closes #162 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정
