### PR TITLE
test: 두번째 기본 인적 사항 테스트 코드 작성

### DIFF
--- a/frontend/cypress/e2e/application.second-personal-information.cy.ts
+++ b/frontend/cypress/e2e/application.second-personal-information.cy.ts
@@ -32,4 +32,16 @@ describe("2번째 인적사항 e2e 테스트", () => {
       ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
     ).click();
   });
+
+  it("전공, 복수전공, 부전공 입력 후 다음 버튼 클릭", () => {
+    cy.goSecondPersonalInformation();
+    cy.get("input.my-2.border.rounded-lg.p-4.w-full")
+      .eq(0)
+      .type("컴퓨터정보통신공학과");
+    cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(1).type("건축학과");
+    cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(2).type("물리학과");
+    cy.get(
+      ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
+    ).click();
+  });
 });

--- a/frontend/cypress/e2e/application.second-personal-information.cy.ts
+++ b/frontend/cypress/e2e/application.second-personal-information.cy.ts
@@ -1,3 +1,13 @@
 describe("2번째 인적사항 e2e 테스트", () => {
   beforeEach(() => cy.viewport(1200, 900));
+
+  it("전공 입력 후 다음 버튼 클릭", () => {
+    cy.goSecondPersonalInformation();
+    cy.get("input.my-2.border.rounded-lg.p-4.w-full")
+      .eq(0)
+      .type("컴퓨터정보통신공학과");
+    cy.get(
+      ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
+    ).click();
+  });
 });

--- a/frontend/cypress/e2e/application.second-personal-information.cy.ts
+++ b/frontend/cypress/e2e/application.second-personal-information.cy.ts
@@ -1,103 +1,67 @@
 describe("2번째 인적사항 e2e 테스트", () => {
-  beforeEach(() => cy.viewport(1200, 900));
+  beforeEach(() => {
+    cy.viewport(1200, 900);
 
-  it("전공 입력 후 다음 버튼 클릭하면 기타 질문 사항으로 이동", () => {
     cy.goSecondPersonalInformation();
+
     cy.get("span")
       .filter((index, element) => Cypress.$(element).text().trim() === "전공*")
       .parent()
       .next("input")
-      .should("exist")
-      .type("컴퓨터정보통신공학과");
-    cy.get("button").contains("다음").should("exist").click();
+      .as("major");
+
+    cy.get("span")
+      .filter(
+        (index, element) => Cypress.$(element).text().trim() === "복수전공"
+      )
+      .parent()
+      .next("input")
+      .as("revengeMajor");
+
+    cy.get("span")
+      .filter((index, element) => Cypress.$(element).text().trim() === "부전공")
+      .parent()
+      .next("input")
+      .as("minor");
+
+    cy.get("button").contains("다음").as("nextButton");
+  });
+
+  it("전공 입력 후 다음 버튼 클릭하면 기타 질문 사항으로 이동", () => {
+    cy.get("@major").type("컴퓨터정보통신공학과");
+    cy.get("@nextButton").click();
   });
 
   it("전공, 복수전공 입력 후 다음 버튼 클릭하면 기타 질문 사항으로 이동", () => {
-    cy.goSecondPersonalInformation();
-    cy.get("span")
-      .filter((index, element) => Cypress.$(element).text().trim() === "전공*")
-      .parent()
-      .next("input")
-      .should("exist")
-      .type("컴퓨터정보통신공학과");
-    cy.get("span")
-      .filter(
-        (index, element) => Cypress.$(element).text().trim() === "복수전공"
-      )
-      .parent()
-      .next("input")
-      .should("exist")
-      .type("건축학과");
-    cy.get("button").contains("다음").should("exist").click();
+    cy.get("@major").type("컴퓨터정보통신공학과");
+    cy.get("@revengeMajor").type("건축학과");
+    cy.get("@nextButton").click();
   });
 
   it("전공, 부전공 입력 후 다음 버튼 클릭하면 기타 질문 사항으로 이동", () => {
-    cy.goSecondPersonalInformation();
-    cy.get("span")
-      .filter((index, element) => Cypress.$(element).text().trim() === "전공*")
-      .parent()
-      .next("input")
-      .should("exist")
-      .type("컴퓨터정보통신공학과");
-    cy.get("span")
-      .filter((index, element) => Cypress.$(element).text().trim() === "부전공")
-      .parent()
-      .next("input")
-      .should("exist")
-      .type("물리학과");
-    cy.get("button").contains("다음").should("exist").click();
+    cy.get("@major").type("컴퓨터정보통신공학과");
+    cy.get("@minor").type("물리학과");
+    cy.get("@nextButton").click();
   });
 
   it("전공, 복수전공, 부전공 입력 후 다음 버튼 클릭하면 기타 질문 사항으로 이동", () => {
-    cy.goSecondPersonalInformation();
-    cy.get("span")
-      .filter((index, element) => Cypress.$(element).text().trim() === "전공*")
-      .parent()
-      .next("input")
-      .should("exist")
-      .type("컴퓨터정보통신공학과");
-    cy.get("span")
-      .filter(
-        (index, element) => Cypress.$(element).text().trim() === "복수전공"
-      )
-      .parent()
-      .next("input")
-      .should("exist")
-      .type("건축학과");
-    cy.get("span")
-      .filter((index, element) => Cypress.$(element).text().trim() === "부전공")
-      .parent()
-      .next("input")
-      .should("exist")
-      .type("물리학과");
-    cy.get("button").contains("다음").should("exist").click();
+    cy.get("@major").type("컴퓨터정보통신공학과");
+    cy.get("@revengeMajor").type("건축학과");
+    cy.get("@minor").type("물리학과");
+    cy.get("@nextButton").click();
   });
 
   it("아무것도 입력하지 않고 다음 버튼 클릭하면 '필수 질문을 작성해주세요.'라는 alert창이 보인다.", () => {
-    cy.goSecondPersonalInformation();
-    cy.get("button").contains("다음").should("exist").click();
+    cy.get("@nextButton").click();
     cy.on("window:alert", (text) => {
       console.log("Alert message:", text);
     });
   });
 
   it("전공을 입력하지 않고 복수전공, 부전공을 입력 후 다음 버튼 클릭하면 '필수 질문을 작성해주세요.'라는 alert창이 보인다.", () => {
-    cy.goSecondPersonalInformation();
-    cy.get("span")
-      .filter(
-        (index, element) => Cypress.$(element).text().trim() === "복수전공"
-      )
-      .parent()
-      .next("input")
-      .should("exist")
-      .type("건축학과");
-    cy.get("span")
-      .filter((index, element) => Cypress.$(element).text().trim() === "부전공")
-      .parent()
-      .next("input")
-      .should("exist")
-      .type("물리학과");
-    cy.get("button").contains("다음").should("exist").click();
+    cy.get("@revengeMajor").type("건축학과");
+    cy.get("@minor").type("물리학과");
+    cy.get("@nextButton").click();
     cy.on("window:alert", (text) => {
       console.log("Alert message:", text);
     });

--- a/frontend/cypress/e2e/application.second-personal-information.cy.ts
+++ b/frontend/cypress/e2e/application.second-personal-information.cy.ts
@@ -10,4 +10,15 @@ describe("2번째 인적사항 e2e 테스트", () => {
       ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
     ).click();
   });
+
+  it("전공, 복수전공 입력 후 다음 버튼 클릭", () => {
+    cy.goSecondPersonalInformation();
+    cy.get("input.my-2.border.rounded-lg.p-4.w-full")
+      .eq(0)
+      .type("컴퓨터정보통신공학과");
+    cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(1).type("물리학과");
+    cy.get(
+      ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
+    ).click();
+  });
 });

--- a/frontend/cypress/e2e/application.second-personal-information.cy.ts
+++ b/frontend/cypress/e2e/application.second-personal-information.cy.ts
@@ -21,4 +21,15 @@ describe("2번째 인적사항 e2e 테스트", () => {
       ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
     ).click();
   });
+
+  it("전공, 부전공 입력 후 다음 버튼 클릭", () => {
+    cy.goSecondPersonalInformation();
+    cy.get("input.my-2.border.rounded-lg.p-4.w-full")
+      .eq(0)
+      .type("컴퓨터정보통신공학과");
+    cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(2).type("물리학과");
+    cy.get(
+      ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
+    ).click();
+  });
 });

--- a/frontend/cypress/e2e/application.second-personal-information.cy.ts
+++ b/frontend/cypress/e2e/application.second-personal-information.cy.ts
@@ -1,0 +1,3 @@
+describe("2번째 인적사항 e2e 테스트", () => {
+  beforeEach(() => cy.viewport(1200, 900));
+});

--- a/frontend/cypress/e2e/application.second-personal-information.cy.ts
+++ b/frontend/cypress/e2e/application.second-personal-information.cy.ts
@@ -54,4 +54,16 @@ describe("2번째 인적사항 e2e 테스트", () => {
       console.log("Alert message:", text);
     });
   });
+
+  it("전공을 입력하지 않고 복수전공, 부전공을 입력 후 버튼 클릭", () => {
+    cy.goSecondPersonalInformation();
+    cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(1).type("건축학과");
+    cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(2).type("물리학과");
+    cy.get(
+      ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
+    ).click();
+    cy.on("window:alert", (text) => {
+      console.log("Alert message:", text);
+    });
+  });
 });

--- a/frontend/cypress/e2e/application.second-personal-information.cy.ts
+++ b/frontend/cypress/e2e/application.second-personal-information.cy.ts
@@ -1,67 +1,103 @@
 describe("2번째 인적사항 e2e 테스트", () => {
   beforeEach(() => cy.viewport(1200, 900));
 
-  it("전공 입력 후 다음 버튼 클릭", () => {
+  it("전공 입력 후 다음 버튼 클릭하면 기타 질문 사항으로 이동", () => {
     cy.goSecondPersonalInformation();
-    cy.get("input.my-2.border.rounded-lg.p-4.w-full")
-      .eq(0)
+    cy.get("span")
+      .filter((index, element) => Cypress.$(element).text().trim() === "전공*")
+      .parent()
+      .next("input")
+      .should("exist")
       .type("컴퓨터정보통신공학과");
-    cy.get(
-      ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
-    ).click();
+    cy.get("button").contains("다음").should("exist").click();
   });
 
-  it("전공, 복수전공 입력 후 다음 버튼 클릭", () => {
+  it("전공, 복수전공 입력 후 다음 버튼 클릭하면 기타 질문 사항으로 이동", () => {
     cy.goSecondPersonalInformation();
-    cy.get("input.my-2.border.rounded-lg.p-4.w-full")
-      .eq(0)
+    cy.get("span")
+      .filter((index, element) => Cypress.$(element).text().trim() === "전공*")
+      .parent()
+      .next("input")
+      .should("exist")
       .type("컴퓨터정보통신공학과");
-    cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(1).type("물리학과");
-    cy.get(
-      ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
-    ).click();
+    cy.get("span")
+      .filter(
+        (index, element) => Cypress.$(element).text().trim() === "복수전공"
+      )
+      .parent()
+      .next("input")
+      .should("exist")
+      .type("건축학과");
+    cy.get("button").contains("다음").should("exist").click();
   });
 
-  it("전공, 부전공 입력 후 다음 버튼 클릭", () => {
+  it("전공, 부전공 입력 후 다음 버튼 클릭하면 기타 질문 사항으로 이동", () => {
     cy.goSecondPersonalInformation();
-    cy.get("input.my-2.border.rounded-lg.p-4.w-full")
-      .eq(0)
+    cy.get("span")
+      .filter((index, element) => Cypress.$(element).text().trim() === "전공*")
+      .parent()
+      .next("input")
+      .should("exist")
       .type("컴퓨터정보통신공학과");
-    cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(2).type("물리학과");
-    cy.get(
-      ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
-    ).click();
+    cy.get("span")
+      .filter((index, element) => Cypress.$(element).text().trim() === "부전공")
+      .parent()
+      .next("input")
+      .should("exist")
+      .type("물리학과");
+    cy.get("button").contains("다음").should("exist").click();
   });
 
-  it("전공, 복수전공, 부전공 입력 후 다음 버튼 클릭", () => {
+  it("전공, 복수전공, 부전공 입력 후 다음 버튼 클릭하면 기타 질문 사항으로 이동", () => {
     cy.goSecondPersonalInformation();
-    cy.get("input.my-2.border.rounded-lg.p-4.w-full")
-      .eq(0)
+    cy.get("span")
+      .filter((index, element) => Cypress.$(element).text().trim() === "전공*")
+      .parent()
+      .next("input")
+      .should("exist")
       .type("컴퓨터정보통신공학과");
-    cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(1).type("건축학과");
-    cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(2).type("물리학과");
-    cy.get(
-      ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
-    ).click();
+    cy.get("span")
+      .filter(
+        (index, element) => Cypress.$(element).text().trim() === "복수전공"
+      )
+      .parent()
+      .next("input")
+      .should("exist")
+      .type("건축학과");
+    cy.get("span")
+      .filter((index, element) => Cypress.$(element).text().trim() === "부전공")
+      .parent()
+      .next("input")
+      .should("exist")
+      .type("물리학과");
+    cy.get("button").contains("다음").should("exist").click();
   });
 
-  it("아무것도 입력하지 않고 다음 버튼 클릭", () => {
+  it("아무것도 입력하지 않고 다음 버튼 클릭하면 '필수 질문을 작성해주세요.'라는 alert창이 보인다.", () => {
     cy.goSecondPersonalInformation();
-    cy.get(
-      ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
-    ).click();
+    cy.get("button").contains("다음").should("exist").click();
     cy.on("window:alert", (text) => {
       console.log("Alert message:", text);
     });
   });
 
-  it("전공을 입력하지 않고 복수전공, 부전공을 입력 후 버튼 클릭", () => {
+  it("전공을 입력하지 않고 복수전공, 부전공을 입력 후 다음 버튼 클릭하면 '필수 질문을 작성해주세요.'라는 alert창이 보인다.", () => {
     cy.goSecondPersonalInformation();
-    cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(1).type("건축학과");
-    cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(2).type("물리학과");
-    cy.get(
-      ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
-    ).click();
+    cy.get("span")
+      .filter(
+        (index, element) => Cypress.$(element).text().trim() === "복수전공"
+      )
+      .parent()
+      .next("input")
+      .should("exist")
+      .type("건축학과");
+    cy.get("span")
+      .filter((index, element) => Cypress.$(element).text().trim() === "부전공")
+      .parent()
+      .next("input")
+      .should("exist")
+      .type("물리학과");
+    cy.get("button").contains("다음").should("exist").click();
     cy.on("window:alert", (text) => {
       console.log("Alert message:", text);
     });

--- a/frontend/cypress/e2e/application.second-personal-information.cy.ts
+++ b/frontend/cypress/e2e/application.second-personal-information.cy.ts
@@ -44,4 +44,14 @@ describe("2번째 인적사항 e2e 테스트", () => {
       ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
     ).click();
   });
+
+  it("아무것도 입력하지 않고 다음 버튼 클릭", () => {
+    cy.goSecondPersonalInformation();
+    cy.get(
+      ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
+    ).click();
+    cy.on("window:alert", (text) => {
+      console.log("Alert message:", text);
+    });
+  });
 });

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -1,37 +1,24 @@
-/// <reference types="cypress" />
-// ***********************************************
-// This example commands.ts shows you how to
-// create various custom commands and overwrite
-// existing commands.
-//
-// For more comprehensive examples of custom
-// commands please read more here:
-// https://on.cypress.io/custom-commands
-// ***********************************************
-//
-//
-// -- This is a parent command --
-// Cypress.Commands.add('login', (email, password) => { ... })
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This will overwrite an existing command --
-// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
-//
-// declare global {
-//   namespace Cypress {
-//     interface Chainable {
-//       login(email: string, password: string): Chainable<void>
-//       drag(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
-//       dismiss(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
-//       visit(originalFn: CommandOriginalFn, url: string, options: Partial<VisitOptions>): Chainable<Element>
-//     }
-//   }
-// }
+declare namespace Cypress {
+  interface Chainable {
+    goSecondPersonalInformation(): Chainable<void>;
+  }
+}
+
+Cypress.Commands.add("goSecondPersonalInformation", () => {
+  cy.visit("http://localhost:3000/application");
+  cy.get('[for=":R7dmlllkq:"]').click();
+  cy.get('[for=":Rblmlllkq:"]').click();
+  cy.get('[for=":r1:"]').click();
+  cy.get(
+    ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
+  ).click(); // 첫번째 인적사항 페이지로 이동
+  cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(0).type("심민보");
+  cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(1).type("01000000000");
+  cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(2).type("111111");
+  cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(3).type("재학");
+  cy.get('[for=":rb:"]').click();
+  cy.get('[for=":re:"]').click();
+  cy.get(
+    ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
+  ).click(); // 두번째 인적사항 페이지로 이동
+});

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -1,3 +1,5 @@
+/// <reference types="cypress" />
+
 declare namespace Cypress {
   interface Chainable {
     goSecondPersonalInformation(): Chainable<void>;

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -5,20 +5,41 @@ declare namespace Cypress {
 }
 
 Cypress.Commands.add("goSecondPersonalInformation", () => {
+  cy.clearAllLocalStorage();
   cy.visit("http://localhost:3000/application");
-  cy.get('[for=":R7dmlllkq:"]').click();
-  cy.get('[for=":Rblmlllkq:"]').click();
-  cy.get('[for=":r1:"]').click();
-  cy.get(
-    ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
-  ).click(); // 첫번째 인적사항 페이지로 이동
-  cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(0).type("심민보");
-  cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(1).type("01000000000");
-  cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(2).type("111111");
-  cy.get("input.my-2.border.rounded-lg.p-4.w-full").eq(3).type("재학");
-  cy.get('[for=":rb:"]').click();
-  cy.get('[for=":re:"]').click();
-  cy.get(
-    ".flex-1.rounded-md.flex.justify-center.items-center.p-4.bg-dark.text-white"
-  ).click(); // 두번째 인적사항 페이지로 이동
+  cy.get("label").contains("개발자").should("exist").click();
+  cy.get("span")
+    .contains("1순위")
+    .next()
+    .contains("label", "APP")
+    .should("exist")
+    .click();
+  cy.get("span")
+    .contains("1순위")
+    .next()
+    .next()
+    .next()
+    .contains("label", "WEB")
+    .should("exist")
+    .click();
+  cy.get("button").contains("다음").should("exist").click();
+  cy.get("span").contains("이름").parent().next().type("심민보");
+  cy.get("span")
+    .contains("연락처")
+    .parent()
+    .next()
+    .type("00000000000")
+    .invoke("val")
+    .should("match", /^\d{3}-\d{4}-\d{4}$/);
+  cy.get("span")
+    .contains("학번")
+    .parent()
+    .next()
+    .type("123456")
+    .invoke("val")
+    .should("match", /^\d{6}$/);
+  cy.get("span").contains("학적상태").parent().next().type("재학");
+  cy.get("label").contains("4학년").should("exist").click();
+  cy.get("label").contains("2학기").should("exist").click();
+  cy.get("button").contains("다음").should("exist").click();
 });

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -15,15 +15,19 @@ Cypress.Commands.add("goSecondPersonalInformation", () => {
     .should("exist")
     .click();
   cy.get("span")
-    .contains("1순위")
-    .next()
-    .next()
+    .filter((index, element) => Cypress.$(element).text().trim() === "2순위")
     .next()
     .contains("label", "WEB")
     .should("exist")
     .click();
   cy.get("button").contains("다음").should("exist").click();
-  cy.get("span").contains("이름").parent().next().type("심민보");
+  cy.get("span")
+    .contains("이름")
+    .parent()
+    .next()
+    .type("심민보")
+    .invoke("val")
+    .should("satisfy", (value) => value.length <= 5);
   cy.get("span")
     .contains("연락처")
     .parent()
@@ -38,7 +42,13 @@ Cypress.Commands.add("goSecondPersonalInformation", () => {
     .type("123456")
     .invoke("val")
     .should("match", /^\d{6}$/);
-  cy.get("span").contains("학적상태").parent().next().type("재학");
+  cy.get("span")
+    .contains("학적상태")
+    .parent()
+    .next()
+    .type("재학")
+    .invoke("val")
+    .should("satisfy", (value) => value.length >= 1);
   cy.get("label").contains("4학년").should("exist").click();
   cy.get("label").contains("2학기").should("exist").click();
   cy.get("button").contains("다음").should("exist").click();


### PR DESCRIPTION
## 주요 변경사항
- 두번째 인적사항 페이지로 이동하는 함수 구현

- 테스트 코드 구현
1. 전공 입력 + 다음 버튼 클릭
2. 전공 입력 + 복수 전공 입력 + 다음 버튼 클릭
3. 전공 입력 + 부전공 입력 + 다음 버튼 클릭
4. 전공 입력 + 복수 전공 입력 + 부전공 입력 + 다음 버튼 클릭
5. 아무것도 입력 x + 다음 버튼 클릭
6. 전공 입력 x + 복수 전공 입력 + 부전공 입력 + 다음 버튼 클릭
## 리뷰어에게...
cypress 에서는 alert 창이 뜨지 않기 때문에 alert 창을 감지해서 console문으로 내용을 출력해주었습니다 !

![image](https://github.com/user-attachments/assets/bfae0fb5-7a63-418c-97ac-e56c09afa1de)

## 관련 이슈

closes #162 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정
