### PR TITLE
feat: 개인정보 수집 안내 페이지 상수 데이터 업데이트

### DIFF
--- a/frontend/app/application/consent/page.tsx
+++ b/frontend/app/application/consent/page.tsx
@@ -1,9 +1,11 @@
 import Txt from "@/components/common/Txt.component";
 import { CURRENT_GENERATION } from "@/src/constants";
-import { FINAL_DATE } from "@/src/constants/application/27";
 import { replaceTwoString } from "@/src/functions/replacer";
 
-const ApplicationConsentPage = () => {
+const ApplicationConsentPage = async () => {
+  const { FINAL_DATE } = await import(
+    `@/src/constants/application/${CURRENT_GENERATION}`
+  );
   const generation = `${CURRENT_GENERATION}`;
   const finalDate = `${FINAL_DATE.year}.${replaceTwoString(
     FINAL_DATE.month

--- a/frontend/src/constants/application/28.ts
+++ b/frontend/src/constants/application/28.ts
@@ -193,13 +193,24 @@ export const APPLICATION_TIMELINE: ApplicationTimeline = {
   disableTime: [],
 };
 
+/**
+ * @description 개인정보 수집에 대한 1차 모집 마감일 상수 데이터
+ * @property {month}: 1차 모집 마감 달 (1-12)
+ * @property {date}: 1차 모집 마감 날짜 (1-31)
+ */
 export const END_DATE = {
-  month: 3,
-  date: 18,
+  month: 9,
+  date: 15,
 };
 
+/**
+ * @description 개인정보 수집에 대한 최종 마감일 상수 데이터
+ * @property {number} year - 최종 모집 마감 연도
+ * @property {number} month - 최종 모집 마감 월 (1-12)
+ * @property {number} date - 최종 모집 마감 일 (1-31)
+ */
 export const FINAL_DATE = {
   year: 2024,
-  month: 3,
-  date: 25,
+  month: 9,
+  date: 30,
 };


### PR DESCRIPTION
## 주요 변경사항

개인 정보 수집 안내 페이지 내용을 업데이트합니다. 

- 페이지에서 사용하는 상수 데이터를 이번 신입모집 일정에 맞추어 업데이트 하였습니다.
- 페이지에서 최신 기수의 상수 데이터를 가져올 수 있도록 동적 import 로 변경하였습니다. 
- 추가적으로 이름이 모호한 느낌이 있어 jsDoc으로 해당 상수에 대해서 설명을 추가하였습니다. 

## 리뷰어에게...

- 큰 변화는 없습니다..! 더 좋은 개선 사항이 있을지 궁금 하기도 하네요!
- 상수 데이터에 설명을 추가한게 조금 어색해 보이기도 하네요. 굳이 라는 생각이 들기도 합니다. 이와 관련해서 의견 부탁드립니다!

## 관련 이슈

closes #169 