### PR TITLE
test: 기타 질문 사항 e2e 테스트

### DIFF
--- a/frontend/cypress/e2e/application.other-questions.cy.ts
+++ b/frontend/cypress/e2e/application.other-questions.cy.ts
@@ -1,4 +1,4 @@
-describe("2번째 인적사항 e2e 테스트", () => {
+describe("기타 질문 사항 e2e 테스트", () => {
   beforeEach(() => {
     cy.viewport(1200, 900);
 

--- a/frontend/cypress/e2e/application.other-questions.cy.ts
+++ b/frontend/cypress/e2e/application.other-questions.cy.ts
@@ -1,0 +1,108 @@
+describe("2번째 인적사항 e2e 테스트", () => {
+  beforeEach(() => {
+    cy.viewport(1200, 900);
+
+    cy.goOtherQuestions();
+
+    cy.get("label")
+      .contains(
+        "학업 외에 병행하고 있거나 향후 계획 중에 있는 활동이 있으시다면 서술해 주세요.*"
+      )
+      .parent()
+      .next("input")
+      .as("plan");
+
+    cy.get("span")
+      .contains("지원 경로(중복 선택 가능)*")
+      .parent()
+      .next()
+      .contains("label", "학과 공지사항")
+      .as("announcement");
+
+    cy.get("span")
+      .contains("지원 경로(중복 선택 가능)*")
+      .parent()
+      .next()
+      .contains("label", "인스타그램")
+      .as("instagram");
+
+    cy.get("span")
+      .contains("지원 경로(중복 선택 가능)*")
+      .parent()
+      .next()
+      .contains("label", "기타")
+      .as("etc");
+
+    cy.get("span")
+      .contains("자기소개 및 에코노베이션에 지원하게 된 계기를 서술해 주세요.")
+      .as("nextPage");
+
+    cy.get("button").contains("다음").as("nextButton");
+  });
+
+  it("사용자는 향후 계획활동을 기입할 수 있다.", () => {
+    cy.get("@plan").type("프로젝트").should("have.value", "프로젝트").clear();
+  });
+
+  it("사용자는 지원 경로를 중복으로 선택가능하다.", () => {
+    cy.get("@announcement").click();
+    cy.get("@instagram").click();
+    cy.get("@announcement")
+      .should("have.class", "text-white")
+      .click()
+      .should("not.have.class", "text-white");
+    cy.get("@instagram")
+      .should("have.class", "text-white")
+      .click()
+      .should("not.have.class", "text-white");
+  });
+
+  it("사용자는 지원 경로에서 기타를 선택할 경우 기타 지원 경로에 관한 내용을 입력할 수 있다.", () => {
+    cy.get("@etc").click();
+    cy.get('input[placeholder="내용을 입력해주세요."]')
+      .type("dev")
+      .should("have.value", "dev")
+      .clear();
+    cy.get("@etc").should("have.class", "text-white").click();
+  });
+
+  it("사용자는 아무것도 작성 및 선택하지 말고 다음버튼을 누를 시, “필수 질문을 작성해주세요.”라는 alert창이 뜬다.", () => {
+    cy.get("@nextButton").click();
+    cy.checkAlert("필수 질문을 작성해주세요.");
+  });
+
+  it("사용자는 향후 계획활동을 기입하지 않고 다음버튼을 누를 시, “필수 질문을 작성해주세요.”라는 alert창이 뜬다. (지원경로 선택 = true)", () => {
+    cy.get("@announcement").click();
+    cy.get("@nextButton").click();
+    cy.checkAlert("필수 질문을 작성해주세요.");
+  });
+
+  it("사용자는 지원경로를 선택하지 않고 다음버튼을 누를 시, “지원경로를 선택해주세요.”라는 alert창이 뜬다. (향후 계획활동 작성 = true)", () => {
+    cy.get("@plan").type("프로젝트").should("have.value", "프로젝트");
+    cy.get("@nextButton").click();
+    cy.checkAlert("지원 경로를 선택해주세요.");
+  });
+
+  it("사용자는 지원경로 중 “기타” 만 선택하고 다음버튼을 누를 시, “지원경로를 선택해주세요.”라는 alert창이 뜬다. (향후 계획활동 작성 = true)", () => {
+    cy.get("@plan").type("프로젝트").should("have.value", "프로젝트");
+    cy.get("@etc").click();
+    cy.get("@nextButton").click();
+    cy.checkAlert("지원 경로를 선택해주세요.");
+  });
+
+  it("사용자는 “기타”가 아닌 지원경로 하나 이상과, “기타”를 선택하고 다음버튼을 누를 시, 다음 페이지로 넘어간다. (향후 계획활동 작성 = true, 지원경로 선택 = true )", () => {
+    cy.get("@plan").type("프로젝트").should("have.value", "프로젝트");
+    cy.get("@announcement").click();
+    cy.get("@etc").click();
+    cy.get("@nextButton").click();
+    cy.get("@nextPage").should("have.class", "text-black");
+  });
+
+  it("사용자는 지원경로 중 “기타”만 선택하고 기타에 관한 내용을 기입한 이후, 다음 버튼을 누를 시, 다음페이지로 넘어간다. (향후 계획활동 작성 = true, 지원 경로 선택 = true)", () => {
+    cy.get("@plan").type("프로젝트").should("have.value", "프로젝트");
+    cy.get("@etc").click();
+    cy.get('input[placeholder="내용을 입력해주세요."]').type("dev");
+    cy.get("@nextButton").click();
+    cy.get("@nextPage").should("have.class", "text-black");
+  });
+});

--- a/frontend/cypress/e2e/application.other-questions.cy.ts
+++ b/frontend/cypress/e2e/application.other-questions.cy.ts
@@ -67,27 +67,27 @@ describe("기타 질문 사항 e2e 테스트", () => {
   });
 
   it("사용자는 아무것도 작성 및 선택하지 말고 다음버튼을 누를 시, “필수 질문을 작성해주세요.”라는 alert창이 뜬다.", () => {
-    cy.get("@nextButton").click();
     cy.checkAlert("필수 질문을 작성해주세요.");
+    cy.get("@nextButton").click();
   });
 
   it("사용자는 향후 계획활동을 기입하지 않고 다음버튼을 누를 시, “필수 질문을 작성해주세요.”라는 alert창이 뜬다. (지원경로 선택 = true)", () => {
+    cy.checkAlert("필수 질문을 작성해주세요.");
     cy.get("@announcement").click();
     cy.get("@nextButton").click();
-    cy.checkAlert("필수 질문을 작성해주세요.");
   });
 
   it("사용자는 지원경로를 선택하지 않고 다음버튼을 누를 시, “지원경로를 선택해주세요.”라는 alert창이 뜬다. (향후 계획활동 작성 = true)", () => {
+    cy.checkAlert("지원 경로를 선택해주세요.");
     cy.get("@plan").type("프로젝트").should("have.value", "프로젝트");
     cy.get("@nextButton").click();
-    cy.checkAlert("지원 경로를 선택해주세요.");
   });
 
   it("사용자는 지원경로 중 “기타” 만 선택하고 다음버튼을 누를 시, “지원경로를 선택해주세요.”라는 alert창이 뜬다. (향후 계획활동 작성 = true)", () => {
+    cy.checkAlert("지원 경로를 선택해주세요.");
     cy.get("@plan").type("프로젝트").should("have.value", "프로젝트");
     cy.get("@etc").click();
     cy.get("@nextButton").click();
-    cy.checkAlert("지원 경로를 선택해주세요.");
   });
 
   it("사용자는 “기타”가 아닌 지원경로 하나 이상과, “기타”를 선택하고 다음버튼을 누를 시, 다음 페이지로 넘어간다. (향후 계획활동 작성 = true, 지원경로 선택 = true )", () => {

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -5,6 +5,7 @@ declare namespace Cypress {
     checkLocalStorage(key: string, expectedValue: string): Chainable<void>;
     checkAlert(expectedValue: string): Chainable<void>;
     goSecondPersonalInformation(): Chainable<void>;
+    goOtherQuestions(): Chainable<void>;
   }
 }
 
@@ -34,6 +35,7 @@ Cypress.Commands.add("goSecondPersonalInformation", () => {
     .contains("label", "APP")
     .should("exist")
     .click();
+  cy.wait(1000);
   cy.get("span")
     .filter((index, element) => Cypress.$(element).text().trim() === "2순위")
     .next()
@@ -72,4 +74,15 @@ Cypress.Commands.add("goSecondPersonalInformation", () => {
   cy.get("label").contains("4학년").should("exist").click();
   cy.get("label").contains("2학기").should("exist").click();
   cy.get("button").contains("다음").should("exist").click();
+});
+
+Cypress.Commands.add("goOtherQuestions", () => {
+  cy.goSecondPersonalInformation();
+  cy.get("span")
+    .filter((index, element) => Cypress.$(element).text().trim() === "전공*")
+    .parent()
+    .next("input")
+    .type("컴퓨터정보통신공학과");
+
+  cy.get("button").contains("다음").click();
 });


### PR DESCRIPTION
## 주요 변경사항
### 테스트 내용
- 사용자는 향후 계획활동을 기입할 수 있다.
- 사용자는 지원 경로를 중복으로 선택가능하다.
- 사용자는 지원 경로에서 기타를 선택할 경우 기타 지원 경로에 관한 내용을 입력할 수 있다.
- 사용자는 아무것도 작성 및 선택하지 말고 다음버튼을 누를 시, “지원경로를 선택해주세요.”라는 alert창이 뜬다.
- 사용자는 향후 계획활동을 기입하지 않고 다음버튼을 누를 시, “지원경로를 선택해주세요.”라는 alert창이 뜬다. (지원경로 선택 = true)
- 사용자는 지원경로를 선택하지 않고 다음버튼을 누를 시, “지원경로를 선택해주세요.”라는 alert창이 뜬다. (향후 계획활동 작성 = true)
- 사용자는 지원경로 중 “기타” 만 선택하고 다음버튼을 누를 시, “지원경로를 선택해주세요.”라는 alert창이 뜬다. (향후 계획활동 작성 = true)
- 사용자는 “기타”가 아닌 지원경로 하나 이상과, “기타”를 선택하고 다음버튼을 누를 시, 다음 페이지로 넘어간다. (향후 계획활동 작성 = true, 지원경로 선택 = true )
- 사용자는 지원경로 중 “기타”만 선택하고 기타에 관한 내용을 기입한 이후, 다음 버튼을 누를 시, 다음페이지로 넘어간다. (향후 계획활동 작성 = true, 지원 경로 선택 = true)

### 추가 사항
- 기타 질문 사항 페이지로 이동하는 goOtherQuestions 함수 구현
- 기타 질문 사항 e2e 테스트

## 리뷰어에게...
건규님께서 만드신 checkAlert 함수가 실제 alert문의 내용을 입력하지 않아도 cypress가 동작할 때 에러를 출력하지 않는 것 같습니다.
```
it("사용자는 지원경로 중 “기타” 만 선택하고 다음버튼을 누를 시, “지원경로를 선택해주세요.”라는 alert창이 뜬다. (향후 계획활동 작성 = true)", () => {
    cy.get("@plan").type("프로젝트").should("have.value", "프로젝트");
    cy.get("@etc").click();
    cy.get("@nextButton").click();
    cy.checkAlert("지원");
  });
```
![image](https://github.com/user-attachments/assets/cef292ee-d9d6-4df9-81cc-29aae2879ec6)

- 테스트 완료
![image](https://github.com/user-attachments/assets/a69f7a47-173d-47bc-aadd-4fbd35edda49)


## 관련 이슈

closes #165 
## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정
