### PR TITLE
fix: 지원 현황 페이지의 면접 가능시간 부분 올바르게 보이도록 수정

### DIFF
--- a/frontend/components/applicant/applicantNode/Timeline.component.tsx
+++ b/frontend/components/applicant/applicantNode/Timeline.component.tsx
@@ -44,7 +44,11 @@ const ApplicantTimelineNode = ({ postId }: ApplicantTimelineNodeProps) => {
           <Txt
             typography="h6"
             className="block pb-8"
-          >{`${time.startTime.getMonth()}월 ${time.startTime.getDate()}일`}</Txt>
+          >{`${time.startTime.toLocaleDateString("ko-KR", {
+            month: "long",
+            day: "numeric",
+            weekday: "short",
+          })}`}</Txt>
           <div className="w-full flex">
             {dateSplicer(time.startTime, time.endTime, seperate).map(
               (date, index) => (


### PR DESCRIPTION
## 주요 변경사항

지원 현황 페이지의 면접 가능시간 부분의 날짜가 올바르게 보이도록 수정하였습니다.

before
![image](https://github.com/user-attachments/assets/fe99b40a-d6db-4f16-98e0-c7f9c6059547)

after
![image](https://github.com/user-attachments/assets/66803f77-85f5-4fe4-bddb-c4353554ce93)


## 리뷰어에게...
큰 변경점이 아니라서 가볍게 보셔도 괜찮을 것 같습니다! 

## 관련 이슈

closes #186
