### PR TITLE
fix: 지원현황 페이지의 질문이 이전 기수 질문으로 보이던 버그 수정

### DIFF
--- a/frontend/src/constants/applicant/28.ts
+++ b/frontend/src/constants/applicant/28.ts
@@ -31,7 +31,7 @@ const APPLICANT: ApplicantNode[] = [
     },
   },
   {
-    id: 3,
+    id: 4,
     title: "기타 질문 사항에 답변해주세요.",
     type: "shortSplit",
     value: [

--- a/frontend/src/constants/applicant/28/designer.ts
+++ b/frontend/src/constants/applicant/28/designer.ts
@@ -69,7 +69,7 @@ export const APPLICANT_DESIGNER = [
     value: { name: "check" },
   } as ApplicantTextareaNode,
   {
-    id: 15,
+    id: 18,
     title: "면접 가능시간을 선택해주세요. (중복 선택 가능)",
     type: "timeline",
   } as ApplicantTimelineNode,

--- a/frontend/src/constants/applicant/28/designer.ts
+++ b/frontend/src/constants/applicant/28/designer.ts
@@ -50,7 +50,7 @@ export const APPLICANT_DESIGNER = [
   {
     id: 12,
     title:
-      "협업(프로젝트, 팀 활동)에 있어서 가장 중요하다고 생각되는 것은 무엇인지 그 이유와 함께 서술해주세요.",
+      "협업(프로젝트, 팀 활동)에 있어서 가장 중요하다고 생각되는 것은 무엇인지 그 이유와 함께 지원자님의 생각을 서술해주세요.",
     type: "textarea",
     value: { name: "collaboration" },
   } as ApplicantTextareaNode,
@@ -62,7 +62,7 @@ export const APPLICANT_DESIGNER = [
     value: { name: "studyPlan" },
   } as ApplicantTextareaNode,
   {
-    id: 14,
+    id: 16,
     title:
       "에코노베이션은 3학기 이상의 활동과 매주 금요일 17시 주간발표에 필수로 참여해야 합니다.\n위 내용을 확인하셨으면 '확인했습니다'를 기입해주세요.",
     type: "textarea",

--- a/frontend/src/constants/applicant/28/designer.ts
+++ b/frontend/src/constants/applicant/28/designer.ts
@@ -64,7 +64,7 @@ export const APPLICANT_DESIGNER = [
   {
     id: 14,
     title:
-      "에코노베이션은 3학기 이상의 활동을 권장하고 있으며 매주 금요일 17시에는 주간발표가 있습니다. 위 내용을 확인하셨으면 '확인했습니다'를 기입해주세요.",
+      "에코노베이션은 3학기 이상의 활동과 매주 금요일 17시 주간발표에 필수로 참여해야 합니다.\n위 내용을 확인하셨으면 '확인했습니다'를 기입해주세요.",
     type: "textarea",
     value: { name: "check" },
   } as ApplicantTextareaNode,

--- a/frontend/src/constants/applicant/28/developer.ts
+++ b/frontend/src/constants/applicant/28/developer.ts
@@ -55,7 +55,7 @@ export const APPLICANT_DEVELOPER = [
   {
     id: 12,
     title:
-      "에코노베이션은 3학기 이상의 활동을 권장하고 있으며 매주 금요일 17시에는 주간발표가 있습니다. 위 내용을 확인하셨으면 '확인했습니다'를 기입해주세요.",
+      "에코노베이션은 3학기 이상의 활동과 매주 금요일 17시 주간발표에 필수로 참여해야 합니다.\n위 내용을 확인하셨으면 '확인했습니다'를 기입해주세요.",
     type: "textarea",
     value: { name: "check" },
   } as ApplicantTextareaNode,

--- a/frontend/src/constants/applicant/28/developer.ts
+++ b/frontend/src/constants/applicant/28/developer.ts
@@ -53,7 +53,7 @@ export const APPLICANT_DEVELOPER = [
     value: { name: "studyPlan" },
   } as ApplicantTextareaNode,
   {
-    id: 12,
+    id: 14,
     title:
       "에코노베이션은 3학기 이상의 활동과 매주 금요일 17시 주간발표에 필수로 참여해야 합니다.\n위 내용을 확인하셨으면 '확인했습니다'를 기입해주세요.",
     type: "textarea",

--- a/frontend/src/constants/applicant/28/developer.ts
+++ b/frontend/src/constants/applicant/28/developer.ts
@@ -60,7 +60,7 @@ export const APPLICANT_DEVELOPER = [
     value: { name: "check" },
   } as ApplicantTextareaNode,
   {
-    id: 13,
+    id: 16,
     title: "면접 가능시간을 선택해주세요. (중복 선택 가능)",
     type: "timeline",
   } as ApplicantTimelineNode,

--- a/frontend/src/constants/applicant/28/manager.ts
+++ b/frontend/src/constants/applicant/28/manager.ts
@@ -67,7 +67,7 @@ export const APPLICANT_MANAGER = [
     value: { name: "check" },
   } as ApplicantTextareaNode,
   {
-    id: 13,
+    id: 17,
     title: "면접 가능시간을 선택해주세요. (중복 선택 가능)",
     type: "timeline",
   } as ApplicantTimelineNode,

--- a/frontend/src/constants/applicant/28/manager.ts
+++ b/frontend/src/constants/applicant/28/manager.ts
@@ -32,35 +32,35 @@ export const APPLICANT_MANAGER = [
     value: { name: "experienceTextarea" },
   } as ApplicantBooleanTextareaNode,
   {
-    id: 8,
+    id: 9,
     title:
       "어떤 일에 도전하고 실패해 본 경험이 있나요? 그 실패를 어떻게 극복했는지 서술해 주세요. (소프트웨어 분야 관련 경험이 아니어도 좋습니다.)",
     type: "textarea",
     value: { name: "failual" },
   } as ApplicantTextareaNode,
   {
-    id: 9,
+    id: 10,
     title:
       "무언가에 깊게 빠지거나 파고 들어본 적이 있나요? 좋아하는 것을 위해서 주변에서 인정할 정도로 깊게  빠져본 적이 있다면 서술해주세요. (소프트웨어 분야 관련 경험이 아니어도 좋습니다.)",
     type: "textarea",
     value: { name: "deep" },
   } as ApplicantTextareaNode,
   {
-    id: 10,
+    id: 11,
     title:
       "협업(프로젝트, 팀 활동)에 있어서 가장 중요하다고 생각되는 것은 무엇인지 그 이유와 함께 지원자님의 생각을 서술해 주세요.",
     type: "textarea",
     value: { name: "collaboration" },
   } as ApplicantTextareaNode,
   {
-    id: 11,
+    id: 12,
     title:
       "에코노베이션에 최종 합격 시 신입 기수로 구성된 팀으로 개발 프로젝트에 참여하고, 목표를 달성하기 위해 스스로 끊임없이 배우고 노력합니다. 에코노베이션에 들어오게 된다면 어떤 목표와 학습 계획을 바탕으로 활동하고 싶나요?",
     type: "textarea",
     value: { name: "studyPlan" },
   } as ApplicantTextareaNode,
   {
-    id: 12,
+    id: 15,
     title:
       "에코노베이션은 3학기 이상의 활동과 매주 금요일 17시 주간발표에 필수로 참여해야 합니다.\n위 내용을 확인하셨으면 '확인했습니다'를 기입해주세요.",
     type: "textarea",

--- a/frontend/src/constants/applicant/28/manager.ts
+++ b/frontend/src/constants/applicant/28/manager.ts
@@ -62,7 +62,7 @@ export const APPLICANT_MANAGER = [
   {
     id: 12,
     title:
-      "에코노베이션은 3학기 이상의 활동을 권장하고 있으며 매주 금요일 17시에는 주간발표가 있습니다. 위 내용을 확인하셨으면 '확인했습니다'를 기입해주세요.",
+      "에코노베이션은 3학기 이상의 활동과 매주 금요일 17시 주간발표에 필수로 참여해야 합니다.\n위 내용을 확인하셨으면 '확인했습니다'를 기입해주세요.",
     type: "textarea",
     value: { name: "check" },
   } as ApplicantTextareaNode,


### PR DESCRIPTION
## 주요 변경사항

질문지를 업데이트 하면서 지원현황 페이지의 질문을 업데이트 하지 않아 지원현황 페이지에서 이전 질문이 보이던 버그가 존재하였습니다.
이를 지원현황 페이지의 질문 업데이트를 통해서 해결하게 되었습니다. 

- 지원현황 페이지의 면접 시간 기입 질문을 업데이트하였습니다.
- 지원현황 페이지의 면접 시간 기입 질문의 질문 번호를 업데이트하였습니다.

<details>
<summary>수정된 모습 보기</summary>

### before
![image](https://github.com/user-attachments/assets/f16690d8-5a25-4551-8d87-50293838471a)

### after
![image](https://github.com/user-attachments/assets/1497eed4-7a9d-4a77-ad6a-d6ab9944d72b)


</details>

## 리뷰어에게...
큰 변경점이 없어 가볍게 확인하셔도 좋을 것 같습니다...!

## 관련 이슈

closes #188 