### PR TITLE
feat: 개발 서버에서 로그인이 가능하게 기능 추가

### DIFF
--- a/frontend/app/application/done/page.tsx
+++ b/frontend/app/application/done/page.tsx
@@ -35,10 +35,7 @@ const ApplicationDonePage = ({
         <div>
           <Link
             className="text-blue-500 hover:underline font-bold"
-            href={
-              "https://recruit.econovation.kr/applicant/pdf-viewer?id=" +
-              (id ?? "")
-            }
+            href={"/applicant/pdf-viewer?id=" + (id ?? "")}
           >
             여기
           </Link>

--- a/frontend/components/kanban/DragDrop.component.tsx
+++ b/frontend/components/kanban/DragDrop.component.tsx
@@ -10,7 +10,11 @@ import { useAtom, useAtomValue } from "jotai";
 import { KanbanSelectedButtonNumberState } from "@/src/stores/kanban/Navbar.atoms";
 import useDragDrop from "@/src/hooks/useDragDrop.hook";
 
-const KanbanColumnView = () => {
+interface KanbanColumnViewProps {
+  generation: string;
+}
+
+const KanbanColumnView = ({ generation }: KanbanColumnViewProps) => {
   const navbarId = useAtomValue(KanbanSelectedButtonNumberState);
 
   const {
@@ -18,7 +22,7 @@ const KanbanColumnView = () => {
     isError,
     isLoading,
   } = useQuery<KanbanColumnData[]>(["kanbanDataArray", navbarId], () =>
-    getAllKanbanData(navbarId)
+    getAllKanbanData(navbarId, generation)
   );
 
   if (!kanbanData || isLoading) {
@@ -65,7 +69,7 @@ const KanbanBoardDragDropComponent = ({
             ref={provided.innerRef}
             {...provided.droppableProps}
           >
-            <KanbanColumnView />
+            <KanbanColumnView generation={generation} />
             <KanbanAddColumnComponent />
             {provided.placeholder}
           </div>

--- a/frontend/components/kanban/column/ColumnWithBackButton.component.tsx
+++ b/frontend/components/kanban/column/ColumnWithBackButton.component.tsx
@@ -31,7 +31,7 @@ const KanbanColumnDetailCard = ({
     isError,
     isLoading,
   } = useQuery<KanbanColumnData[]>(["kanbanDataArray", generation], () =>
-    getAllKanbanData(navbarId)
+    getAllKanbanData(navbarId, generation)
   );
 
   if (!kanbanDataArray || isLoading) {

--- a/frontend/src/apis/kanban/index.ts
+++ b/frontend/src/apis/kanban/index.ts
@@ -19,9 +19,11 @@ export interface KanbanCardReq {
 }
 
 // TODO: card api 추가 시 수정 필요
-export const getKanbanCards = async (columnId: string) => {
+export const getKanbanCards = async (columnId: string, generation: string) => {
   const { data } = await https.get<KanbanCardReq[]>(
-    `/navigations/${columnId}/boards`
+    `/navigations/${columnId}/boards?${new URLSearchParams({
+      year: generation,
+    })}`
   );
 
   return data;
@@ -90,10 +92,11 @@ export const postAddCard = async ({ columnId, title }: addCardReq) => {
 };
 
 export const getAllKanbanData = async (
-  navigationId: string
+  navigationId: string,
+  generation: string
 ): Promise<KanbanColumnData[]> => {
   const columnsData = await getColums(navigationId);
-  const cardsData = await getKanbanCards(navigationId);
+  const cardsData = await getKanbanCards(navigationId, generation);
 
   return columnsData.map((column) => {
     const startColumnCardData = cardsData

--- a/frontend/src/apis/user/index.ts
+++ b/frontend/src/apis/user/index.ts
@@ -27,6 +27,7 @@ export const signIn = async ({ email, password }: SignInReq) => {
 export const signOut = async () => {
   try {
     await https.post<SignInRes>("/logout");
+    window.localStorage.removeItem("accessToken");
     return true;
   } catch (e) {
     return false;

--- a/frontend/src/apis/user/index.ts
+++ b/frontend/src/apis/user/index.ts
@@ -15,6 +15,7 @@ export const signIn = async ({ email, password }: SignInReq) => {
     const { data } = await https.post<SignInRes>("/login", { email, password });
     if (data satisfies SignInRes) {
       alert("로그인이 성공하였습니다");
+      window.localStorage.setItem("accessToken", data.accessToken);
     }
 
     return true;

--- a/frontend/src/functions/axios.ts
+++ b/frontend/src/functions/axios.ts
@@ -8,7 +8,7 @@ const https = axios.create({
 https.defaults.withCredentials = true;
 
 https.interceptors.request.use((config) => {
-  const token = JSON.parse(localStorage.getItem("accessToken") ?? '""');
+  const token = localStorage.getItem("accessToken");
   if (token) {
     config.headers["Authorization"] = `Bearer ${token}`;
   }


### PR DESCRIPTION
## 주요 변경사항

## 리뷰어에게...
- 기존의 interceptors가 제대로 작동하지 않게 작성되어 있어서 작동이 잘 되게 변경하였습니다. (로컬 스토리지에 accessToken가 있으면 api request에 Authorization에 넣어주었습니다.)
- 로그인 성공 시 로컬 스토리지에 accessToken 저장하였습니다.
- 로그아웃 시 로컬 스토리지의 accessToken을 삭제하였습니다.
- 백엔드 요구사항에 맞게 api 요청의 쿼리 파라미터에 year를 추가하였습니다.
- 지원서 작성하고 나오는 페이지에서 여기 버튼을 클릭 시 기존에는 고정된 url로 이동하였는데 접속한 url에 따라 유동적으로 변경하였습니다.

## 관련 이슈

closes #190 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
