### PR TITLE
[FE] feat: 면접 기록 지원서 조회 API query parameter 추가

### DIFF
--- a/frontend/app/(WithNavbar)/interview/[generation]/page.tsx
+++ b/frontend/app/(WithNavbar)/interview/[generation]/page.tsx
@@ -17,7 +17,7 @@ const InterviewPage = ({ params: { generation } }: InterviewPageProps) => {
         <Search />
         <SortList sortList={ORDER_MENU.INTERVIEW} />
       </div>
-      <InterviewBoard />
+      <InterviewBoard generation={generation} />
       <InterviewPageNavbar generation={generation} />
     </div>
   );

--- a/frontend/components/interview/Board.tsx
+++ b/frontend/components/interview/Board.tsx
@@ -11,7 +11,11 @@ import { getInterviewRecordByPageWithOrder } from "@/src/apis/interview";
 import { ORDER_MENU } from "@/src/constants";
 import { useSearchQuery } from "@/src/hooks/useSearchQuery";
 
-const InterviewBoard = () => {
+interface InterviewBoardProps {
+  generation: string;
+}
+
+const InterviewBoard = ({ generation }: InterviewBoardProps) => {
   const [applicantId, setApplicantId] = useAtom(interViewApplicantIdState);
   const searchParams = useSearchParams();
   const pageIndex = searchParams.get("page") || "1";
@@ -31,8 +35,9 @@ const InterviewBoard = () => {
   };
 
   const { data, isLoading } = useQuery({
-    queryKey: ["allInterviewRecord", pageIndex, order],
-    queryFn: () => getInterviewRecordByPageWithOrder(+pageIndex, order),
+    queryKey: ["allInterviewRecord", pageIndex, order, generation],
+    queryFn: () =>
+      getInterviewRecordByPageWithOrder(+pageIndex, order, generation),
   });
 
   if (!data || isLoading) {

--- a/frontend/components/interview/Board.tsx
+++ b/frontend/components/interview/Board.tsx
@@ -37,7 +37,11 @@ const InterviewBoard = ({ generation }: InterviewBoardProps) => {
   const { data, isLoading } = useQuery({
     queryKey: ["allInterviewRecord", pageIndex, order, generation],
     queryFn: () =>
-      getInterviewRecordByPageWithOrder(+pageIndex, order, generation),
+      getInterviewRecordByPageWithOrder({
+        page: +pageIndex,
+        sortType: order,
+        year: generation,
+      }),
   });
 
   if (!data || isLoading) {

--- a/frontend/components/interview/PageNavbar.tsx
+++ b/frontend/components/interview/PageNavbar.tsx
@@ -29,8 +29,8 @@ const InterviewPageNavbar = ({ generation }: InterviewPageNavbarProps) => {
     isLoading,
     isError,
   } = useQuery(
-    ["allApplicant", generation],
-    () => getInterviewRecordByPageWithOrder(+pageIndex, order),
+    ["allApplicant", order, generation],
+    () => getInterviewRecordByPageWithOrder(+pageIndex, order, generation),
     {
       enabled: !!generation,
     }

--- a/frontend/components/interview/PageNavbar.tsx
+++ b/frontend/components/interview/PageNavbar.tsx
@@ -30,7 +30,12 @@ const InterviewPageNavbar = ({ generation }: InterviewPageNavbarProps) => {
     isError,
   } = useQuery(
     ["allApplicant", order, generation],
-    () => getInterviewRecordByPageWithOrder(+pageIndex, order, generation),
+    () =>
+      getInterviewRecordByPageWithOrder({
+        page: +pageIndex,
+        sortType: order,
+        year: generation,
+      }),
     {
       enabled: !!generation,
     }

--- a/frontend/src/apis/interview/index.ts
+++ b/frontend/src/apis/interview/index.ts
@@ -21,12 +21,14 @@ interface RecordsByPageRes {
 
 export const getInterviewRecordByPageWithOrder = async (
   page: number,
-  order: string
+  order: string,
+  year: string
 ) => {
+  const sq = new URLSearchParams({ sortType: order, year });
   const {
     data: { records, pageInfo },
   } = await https.get<RecordsByPageRes>(
-    `/page/${page}/records?sortType=${order}`
+    `/page/${page}/records?${sq.toString()}`
   );
 
   return {

--- a/frontend/src/apis/interview/index.ts
+++ b/frontend/src/apis/interview/index.ts
@@ -19,16 +19,20 @@ interface RecordsByPageRes {
   pageInfo: PageInfo;
 }
 
-export const getInterviewRecordByPageWithOrder = async (
-  page: number,
-  order: string,
-  year: string
-) => {
-  const sq = new URLSearchParams({ sortType: order, year });
+interface GetInterviewRecordByPageWithOrderReq {
+  page: number;
+  sortType: string;
+  year: string;
+}
+
+export const getInterviewRecordByPageWithOrder = async ({
+  page,
+  ...queryParams
+}: GetInterviewRecordByPageWithOrderReq) => {
   const {
     data: { records, pageInfo },
   } = await https.get<RecordsByPageRes>(
-    `/page/${page}/records?${sq.toString()}`
+    `/page/${page}/records?${new URLSearchParams(queryParams)}`
   );
 
   return {


### PR DESCRIPTION
## 주요 변경사항
아래 API 문서에 맞게 면접 기록 지원서 조회 API에 query parameter를 추가하였습니다. 
- https://angry-pickle-bd8.notion.site/1e6961b984034c0490b3388799e5606b?pvs=4

변경 페이지
 - `/interview/{generation}`


## 관련 이슈
closes #194 

