### PR TITLE
fix: 기획자 포트폴리오가 보이지 않는 문제 해결

### DIFF
--- a/frontend/components/applicant/applicantNode/Portfolio.tsx
+++ b/frontend/components/applicant/applicantNode/Portfolio.tsx
@@ -27,7 +27,7 @@ const Portfolio = ({ data }: PortfolioProps) => {
       <Txt typography="h4">포트폴리오</Txt>
       <div className="flex gap-4">
         <div className="flex-1 flex flex-col">
-          <Txt typography="h6">링크(개발자)</Txt>
+          <Txt typography="h6">링크</Txt>
           {portfolio.map((url: string, index: number) => {
             return (
               <Link href={url} target="_blank" key={index}>

--- a/frontend/components/applicant/applicantNode/Portfolio.tsx
+++ b/frontend/components/applicant/applicantNode/Portfolio.tsx
@@ -18,12 +18,16 @@ const Portfolio = ({ data }: PortfolioProps) => {
     .split(regex)
     .map((url: string) => url.trim());
 
+  const fileUrlForPlanner = applicantDataFinder(data, "fileUrlforPlanner")
+    .split(regex)
+    .map((url: string) => url.trim());
+
   return (
     <>
       <Txt typography="h4">포트폴리오</Txt>
       <div className="flex gap-4">
         <div className="flex-1 flex flex-col">
-          <Txt typography="h6">링크</Txt>
+          <Txt typography="h6">링크(개발자)</Txt>
           {portfolio.map((url: string, index: number) => {
             return (
               <Link href={url} target="_blank" key={index}>
@@ -42,6 +46,18 @@ const Portfolio = ({ data }: PortfolioProps) => {
             );
           })}
         </div>
+        {!!fileUrlForPlanner && (
+          <div className="flex-1 flex flex-col">
+            <Txt typography="h6">이번 학기 프로젝트 기획서</Txt>
+            {fileUrlForPlanner.map((url: string, index: number) => {
+              return (
+                <Link href={url} target="_blank" key={index}>
+                  <Txt className="break-all">{url}</Txt>
+                </Link>
+              );
+            })}
+          </div>
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
## 주요 변경사항
### AS-IS
![image](https://github.com/user-attachments/assets/7c57729c-bf4c-4359-a647-9f51123a89f2)
### TO-BE
![image](https://github.com/user-attachments/assets/ef88511f-f780-44b1-9578-820d3dacac1d)

## 리뷰어에게...
`fileUrlforPlanner` 를 Portfolio 컴포넌트에서 읽어올 수 있도록 수정하였습니다.

## 관련 이슈
- closes #206 


