### PR TITLE
feat: 칸반보드 상세 페이지에서 지원 상태 확인 및 지원 상태 변경 가능하게 구현

### DIFF
--- a/frontend/components/applicant/DetailLeft.component.tsx
+++ b/frontend/components/applicant/DetailLeft.component.tsx
@@ -24,7 +24,7 @@ const ApplicantDetailLeft = ({
 
   return (
     <>
-      <ApplicantResource data={data} postId={postId} />
+      <ApplicantResource data={data} postId={postId} generation={generation} />
       <ApplicantLabel postId={postId} generation={generation} />
       <ApplicantComment
         cardId={cardId}

--- a/frontend/components/applicant/applicantNode/CustomResource.component.tsx
+++ b/frontend/components/applicant/applicantNode/CustomResource.component.tsx
@@ -35,7 +35,10 @@ const ApplicantResource = ({
     () => getApplicantState(navbarId, `${applicantId}`, generation)
   );
 
-  const { data: myInfo } = useQuery(["user"], getMyInfo);
+  const { data: myInfo, isLoading: myInfoLoading } = useQuery(
+    ["user"],
+    getMyInfo
+  );
 
   const [passState, setPassState] =
     useState<ApplicantPassState>("non-processed");
@@ -63,7 +66,7 @@ const ApplicantResource = ({
     }
   }, [initialState]);
 
-  if (isLoading) {
+  if (!initialState || isLoading || !myInfo || myInfoLoading) {
     return <></>;
   }
 

--- a/frontend/components/applicant/applicantNode/CustomResource.component.tsx
+++ b/frontend/components/applicant/applicantNode/CustomResource.component.tsx
@@ -94,8 +94,8 @@ const ApplicantResource = ({
             "field"
           )}] ${applicantDataFinder(data, "name")}`}</Txt>
         </div>
-        {(myInfo?.role === "ROLE_OPERATION" ||
-          myInfo?.role === "ROLE_PRESIDENT") && (
+        {(myInfo.role === "ROLE_OPERATION" ||
+          myInfo.role === "ROLE_PRESIDENT") && (
           <div className="flex gap-5">
             <button
               onClick={onFailedButtonClick}

--- a/frontend/components/applicant/applicantNode/CustomResource.component.tsx
+++ b/frontend/components/applicant/applicantNode/CustomResource.component.tsx
@@ -71,7 +71,7 @@ const ApplicantResource = ({
   }, [initialState]);
 
   if (!initialState || isLoading || !myInfo || myInfoLoading) {
-    return <></>;
+    return <div>로딩중...</div>;
   }
 
   if (isError || myInfoError) {

--- a/frontend/components/applicant/applicantNode/CustomResource.component.tsx
+++ b/frontend/components/applicant/applicantNode/CustomResource.component.tsx
@@ -30,15 +30,19 @@ const ApplicantResource = ({
   const applicantId = searchParams.get("applicantId");
   const queryClient = useQueryClient();
 
-  const { data: initialState, isLoading } = useQuery(
-    ["applicantState", applicantId],
-    () => getApplicantState(navbarId, `${applicantId}`, generation)
+  const {
+    data: initialState,
+    isLoading,
+    isError,
+  } = useQuery(["applicantState", applicantId], () =>
+    getApplicantState(navbarId, `${applicantId}`, generation)
   );
 
-  const { data: myInfo, isLoading: myInfoLoading } = useQuery(
-    ["user"],
-    getMyInfo
-  );
+  const {
+    data: myInfo,
+    isLoading: myInfoLoading,
+    isError: myInfoError,
+  } = useQuery(["user"], getMyInfo);
 
   const [passState, setPassState] =
     useState<ApplicantPassState>("non-processed");
@@ -68,6 +72,10 @@ const ApplicantResource = ({
 
   if (!initialState || isLoading || !myInfo || myInfoLoading) {
     return <></>;
+  }
+
+  if (isError || myInfoError) {
+    return <div>에러 발생</div>;
   }
 
   return (

--- a/frontend/components/applicant/applicantNode/CustomResource.component.tsx
+++ b/frontend/components/applicant/applicantNode/CustomResource.component.tsx
@@ -1,10 +1,5 @@
 import Txt from "@/components/common/Txt.component";
-import {
-  ApplicantReq,
-  getApplicantState,
-  getApplicantStateRes,
-  patchApplicantState,
-} from "@/src/apis/applicant";
+import { ApplicantReq, patchApplicantState } from "@/src/apis/applicant";
 import { applicantDataFinder } from "@/src/functions/finder";
 import Portfolio from "./Portfolio";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -13,6 +8,8 @@ import KanbanCardApplicantStatusLabel from "@/components/kanban/card/CardApplica
 import { useAtomValue } from "jotai";
 import { KanbanSelectedButtonNumberState } from "@/src/stores/kanban/Navbar.atoms";
 import { getMyInfo } from "@/src/apis/interview";
+import { findApplicantState } from "@/src/utils/applicant";
+import { ApplicantPassState, getKanbanCards } from "@/src/apis/kanban";
 
 interface ApplicantResourceProps {
   data: ApplicantReq[];
@@ -36,7 +33,12 @@ const ApplicantResource = ({
     isError,
   } = useQuery({
     queryKey: ["applicantState", applicantId, navbarId],
-    queryFn: () => getApplicantState(navbarId, `${applicantId}`, generation),
+    queryFn: async () =>
+      findApplicantState(
+        await getKanbanCards(navbarId, generation),
+        `${applicantId}`
+      ),
+    staleTime: 3000,
   });
 
   const {
@@ -57,7 +59,7 @@ const ApplicantResource = ({
         navbarId,
       ]);
 
-      const snapshotState = queryClient.getQueryData<getApplicantStateRes>([
+      const snapshotState = queryClient.getQueryData<ApplicantPassState>([
         "applicantState",
         applicantId,
         navbarId,

--- a/frontend/components/applicant/applicantNode/CustomResource.component.tsx
+++ b/frontend/components/applicant/applicantNode/CustomResource.component.tsx
@@ -49,11 +49,11 @@ const ApplicantResource = ({
     },
   });
 
-  const handleFailedButtonClick = () => {
+  const onFailedButtonClick = () => {
     mutate("non-pass");
   };
 
-  const handlePassedButtonClick = () => {
+  const onPassedButtonClick = () => {
     mutate("pass");
   };
 
@@ -86,13 +86,13 @@ const ApplicantResource = ({
           myInfo?.role === "ROLE_PRESIDENT") && (
           <div className="flex gap-5">
             <button
-              onClick={handleFailedButtonClick}
+              onClick={onFailedButtonClick}
               className="bg-zinc-200 w-20 h-20 hover:bg-sky-400 rounded-xl"
             >
               불합격
             </button>
             <button
-              onClick={handlePassedButtonClick}
+              onClick={onPassedButtonClick}
               className="bg-zinc-200 w-20 h-20 hover:bg-sky-400 rounded-xl"
             >
               합격

--- a/frontend/components/applicant/applicantNode/CustomResource.component.tsx
+++ b/frontend/components/applicant/applicantNode/CustomResource.component.tsx
@@ -10,7 +10,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import KanbanCardApplicantStatusLabel from "@/components/kanban/card/CardApplicantStatusLabel";
-import { ApplicantPassState, getAllKanbanData } from "@/src/apis/kanban";
+import { ApplicantPassState } from "@/src/apis/kanban";
 import { useAtomValue } from "jotai";
 import { KanbanSelectedButtonNumberState } from "@/src/stores/kanban/Navbar.atoms";
 import { getMyInfo } from "@/src/apis/interview";

--- a/frontend/components/applicant/applicantNode/CustomResource.component.tsx
+++ b/frontend/components/applicant/applicantNode/CustomResource.component.tsx
@@ -34,9 +34,10 @@ const ApplicantResource = ({
     data: initialState,
     isLoading,
     isError,
-  } = useQuery(["applicantState", applicantId], () =>
-    getApplicantState(navbarId, `${applicantId}`, generation)
-  );
+  } = useQuery({
+    queryKey: ["applicantState", applicantId, navbarId],
+    queryFn: () => getApplicantState(navbarId, `${applicantId}`, generation),
+  });
 
   const {
     data: myInfo,

--- a/frontend/components/applicant/applicantNode/CustomResource.component.tsx
+++ b/frontend/components/applicant/applicantNode/CustomResource.component.tsx
@@ -32,7 +32,7 @@ const ApplicantResource = ({
 
   const { data: initialState, isLoading } = useQuery(
     ["applicantState", applicantId],
-    () => getApplicantState(navbarId, applicantId as string, generation)
+    () => getApplicantState(navbarId, `${applicantId}`, generation)
   );
 
   const { data: myInfo } = useQuery(["user"], getMyInfo);
@@ -42,7 +42,7 @@ const ApplicantResource = ({
 
   const { mutate } = useMutation({
     mutationFn: (afterState: "non-pass" | "pass") =>
-      patchApplicantState(applicantId as string, afterState),
+      patchApplicantState(`${applicantId}`, afterState),
     onSuccess: (data) => {
       queryClient.invalidateQueries(["kanbanDataArray", generation]);
       setPassState(data.passState);

--- a/frontend/components/kanban/column/ColumnWithBackButton.component.tsx
+++ b/frontend/components/kanban/column/ColumnWithBackButton.component.tsx
@@ -30,9 +30,11 @@ const KanbanColumnDetailCard = ({
     data: kanbanDataArray,
     isError,
     isLoading,
-  } = useQuery<KanbanColumnData[]>(["kanbanDataArray", generation], () =>
-    getAllKanbanData(navbarId, generation)
-  );
+  } = useQuery<KanbanColumnData[]>({
+    queryKey: ["kanbanDataArray", generation],
+    queryFn: () => getAllKanbanData(navbarId, generation),
+    staleTime: 3000,
+  });
 
   if (!kanbanDataArray || isLoading) {
     return <div>로딩중...</div>;

--- a/frontend/src/apis/applicant/index.ts
+++ b/frontend/src/apis/applicant/index.ts
@@ -133,7 +133,7 @@ export const getApplicantTimeTables = async (id: string) => {
   return data;
 };
 
-interface patchApplicantStateRes {
+interface PatchApplicantStateRes {
   passState: ApplicantPassState;
 }
 
@@ -141,7 +141,7 @@ export const patchApplicantState = async (
   id: string,
   afterState: "non-pass" | "pass"
 ) => {
-  const { data } = await https.patch<patchApplicantStateRes>(
+  const { data } = await https.patch<PatchApplicantStateRes>(
     `/applicants/${id}/state?afterState=${afterState}`
   );
 

--- a/frontend/src/apis/applicant/index.ts
+++ b/frontend/src/apis/applicant/index.ts
@@ -133,22 +133,28 @@ export const getApplicantTimeTables = async (id: string) => {
   return data;
 };
 
+interface patchApplicantStateRes {
+  passState: ApplicantPassState;
+}
+
 export const patchApplicantState = async (
   id: string,
   afterState: "non-pass" | "pass"
 ) => {
-  const { data } = await https.patch<KanbanCardReq["state"]>(
+  const { data } = await https.patch<patchApplicantStateRes>(
     `/applicants/${id}/state?afterState=${afterState}`
   );
 
   return data;
 };
 
+type getApplicantStateRes = ApplicantPassState | undefined;
+
 export const getApplicantState = async (
   navigationId: string,
   applicantId: string,
   generation: string
-): Promise<ApplicantPassState | undefined> => {
+): Promise<getApplicantStateRes> => {
   const cardsData = await getKanbanCards(navigationId, generation);
 
   return cardsData.find((card) => card.applicantId === applicantId)?.state

--- a/frontend/src/apis/applicant/index.ts
+++ b/frontend/src/apis/applicant/index.ts
@@ -1,6 +1,7 @@
 import { getAllInterviewerWithOrder } from "@/src/apis/interview";
 import { APPLICANT_KEYS } from "@/src/constants";
 import { https } from "@/src/functions/axios";
+import { ApplicantPassState, getKanbanCards, KanbanCardReq } from "../kanban";
 
 export interface ApplicantReq {
   name: string;
@@ -128,6 +129,17 @@ export const postApplicantLabel = async (
 
 export const getApplicantTimeTables = async (id: string) => {
   const { data } = await https.get<number[]>(`/applicants/${id}/timetables`);
+
+  return data;
+};
+
+export const patchApplicantState = async (
+  id: string,
+  afterState: "non-pass" | "pass"
+) => {
+  const { data } = await https.patch<KanbanCardReq["state"]>(
+    `/applicants/${id}/state?afterState=${afterState}`
+  );
 
   return data;
 };

--- a/frontend/src/apis/applicant/index.ts
+++ b/frontend/src/apis/applicant/index.ts
@@ -143,3 +143,14 @@ export const patchApplicantState = async (
 
   return data;
 };
+
+export const getApplicantState = async (
+  navigationId: string,
+  applicantId: string,
+  generation: string
+): Promise<ApplicantPassState | undefined> => {
+  const cardsData = await getKanbanCards(navigationId, generation);
+
+  return cardsData.find((card) => card.applicantId === applicantId)?.state
+    .passState;
+};

--- a/frontend/src/apis/applicant/index.ts
+++ b/frontend/src/apis/applicant/index.ts
@@ -147,16 +147,3 @@ export const patchApplicantState = async (
 
   return data;
 };
-
-export type getApplicantStateRes = ApplicantPassState | undefined;
-
-export const getApplicantState = async (
-  navigationId: string,
-  applicantId: string,
-  generation: string
-): Promise<getApplicantStateRes> => {
-  const cardsData = await getKanbanCards(navigationId, generation);
-
-  return cardsData.find((card) => card.applicantId === applicantId)?.state
-    .passState;
-};

--- a/frontend/src/apis/applicant/index.ts
+++ b/frontend/src/apis/applicant/index.ts
@@ -148,7 +148,7 @@ export const patchApplicantState = async (
   return data;
 };
 
-type getApplicantStateRes = ApplicantPassState | undefined;
+export type getApplicantStateRes = ApplicantPassState | undefined;
 
 export const getApplicantState = async (
   navigationId: string,

--- a/frontend/src/utils/applicant/index.ts
+++ b/frontend/src/utils/applicant/index.ts
@@ -1,0 +1,9 @@
+import { KanbanCardReq } from "@/src/apis/kanban";
+
+export const findApplicantState = (
+  cardsData: KanbanCardReq[],
+  applicantId: string
+) => {
+  return cardsData.find((card) => card.applicantId === applicantId)?.state
+    .passState;
+};


### PR DESCRIPTION
## 주요 변경사항
![image](https://github.com/user-attachments/assets/6cdd93be-ce06-4682-b6ac-3aa004882a54)
- 지원자의 지원 상태를 변경하는 api 함수 구현 (patchApplicantState)
- 특정한 지원자의 상태를 가져오는 api 함수 구현 (getApplicantState)
- 관리자와 회장단에게만 지원자의 상태를 변경할 수 있는 버튼을 보이게 함.
- 지원자의 지원 상태를 학과 옆에 표시

## 리뷰어에게...
### 문제 상황
회장단과 관리자만 지원자의 지원 상태 변경이 가능
- 해결 방안
1. 회장단과 관리자에게만 버튼이 보이도록 한다.
2. 모든 사람에게 버튼이 보이도록 하고 권한이 없는 사람이 버튼을 클릭 시 alert를 띄운다.

저는 1번이 맞다고 생각하여 1번으로 구현하였는데 다른 분들의 의견도 궁금합니다 !
## 관련 이슈

closes #199 