### PR TITLE
fix: 관리자가 아닌 사용자에게 navbar에 불필요한 문자가 보이는 버그 수정

### DIFF
--- a/frontend/components/common/navbar/NavbarManagePassState.tsx
+++ b/frontend/components/common/navbar/NavbarManagePassState.tsx
@@ -17,11 +17,11 @@ export const NavbarManagePassState = ({
   const generation = currentPath.split("/")[2];
   const { data: userData, isLoading } = useQuery(["user"], getMyInfo);
   if (isLoading || !userData) {
-    return <div>Loading...</div>;
+    return null;
   }
 
   if (userData.role !== "ROLE_OPERATION") {
-    return <div>관리자만 접근이 가능합니다.</div>;
+    return null;
   }
 
   return (


### PR DESCRIPTION
## 주요 변경사항

기존에 네브바에 관리자가 아닌 계정으로 접속시 "관리자만 접근이 가능합니다." 문구가 보였습니다. 

![image](https://github.com/user-attachments/assets/2c5dccce-e2a8-42bb-b85f-c0fa267b1f7f)

이는 이전에 저의 [pr](https://github.com/JNU-econovation/econo-recruit-fe/pull/205)에서 해당 컴포넌트의 요구사항에 맞지 않는 수정을 해서 문제가 발행하였습니다. 

네브바의 합/불 관리 페이지 버튼은 사용자의 role을 가져오는 도중, 그리고 가져온 role이 관리자가 아닌 경우에 아무런 것도 보이지 않도록 해야 한다고 생각합니다. (실제로 이와 동일한 동작(?)을 하는 네브바의 관리자 페이지 부분도 동일하게 작성되어 있습니다.)
이에 맞추어 ( `isLoading`, `!data`, .`role !== "ROLE_OPERATION`" )인 상에서는 아무런 것도 보여주지 않도록 변경하였습니다. 

<details>
<summary>관리자 페이지 부분 로직</summary>

```
export const NavbarOperation = ({
  currentType,
  isShort,
}: NavbarOperationProps) => {
  const currentPath = usePathname();
  const generation = currentPath.split("/")[2];
  const { data: userData } = useQuery(["user"], getMyInfo);
  if (!userData) {
    return <div></div>; // 여기또한 아무런 값을 보여주지 않고 있습니다. 
  }

  if (userData.role !== "ROLE_OPERATION") {
    return <div></div>;
  }

  return (
    <CommonNavbarCell
      currentType={currentType}
      isShort={isShort}
      href={`/admin/${generation}`}
      short_title="관리자"
      title="관리자 페이지"
      target="_self"
      type="admin"
    />
  );
};

```

여기서도  ( `isLoading`, `!data`, .`role !== "ROLE_OPERATION`" )인 상에서는 아무런 것도 보여주지 않습니다! 

이와 동일하게 동작해야하는 버튼이므로 해당 경우에 null을 반환하도록 수정하였습니다. 

</details>

## 리뷰어에게...

- 제가 해당 부분을 설계한 사람이 아니므로, 해당 컴포넌트의 요구사항을 제멋대로 해석한 것일 수 있습니다. 해당 컴포넌트에 대한 요구사항에 대해서 올바르게 판단한 것이 맞을지 함께 이야기해 보면 좋을 것 같습니다.

## 관련 이슈

closes #210
