### PR TITLE
feat: 지원현황/면접기록 목록페이지에서 합불상태를 조회할 수 있다.

### DIFF
--- a/frontend/components/applicant/Board.tsx
+++ b/frontend/components/applicant/Board.tsx
@@ -11,6 +11,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useSearchParams } from "next/navigation";
 import { ORDER_MENU } from "@/src/constants";
 import { useSearchQuery } from "@/src/hooks/useSearchQuery";
+import { type ApplicantPassState } from "../../src/apis/kanban";
 
 interface ApplicantBoardProps {
   generation: string;
@@ -59,7 +60,6 @@ const ApplicantBoard = ({ generation }: ApplicantBoardProps) => {
       "name"
     )}`,
     subElements: [
-      `${applicantDataFinder(value, "passState").passState}`,
       `${applicantDataFinder(value, "field1")}/${applicantDataFinder(
         value,
         "field2"
@@ -74,6 +74,9 @@ const ApplicantBoard = ({ generation }: ApplicantBoardProps) => {
             Number(applicantDataFinder(value, "uploadDate"))
           ).toLocaleString("ko-KR", { dateStyle: "short" }),
     ],
+    passState: `${
+      applicantDataFinder(value, "passState").passState
+    }` as ApplicantPassState,
   }));
 
   return (

--- a/frontend/components/applicant/Board.tsx
+++ b/frontend/components/applicant/Board.tsx
@@ -59,8 +59,10 @@ const ApplicantBoard = ({ generation }: ApplicantBoardProps) => {
       "name"
     )}`,
     subElements: [
-      applicantDataFinder(value, "field1"),
-      applicantDataFinder(value, "field2"),
+      `${applicantDataFinder(value, "field1")}/${applicantDataFinder(
+        value,
+        "field2"
+      )}`,
       `${applicantDataFinder(value, "grade")} ${applicantDataFinder(
         value,
         "semester"

--- a/frontend/components/applicant/Board.tsx
+++ b/frontend/components/applicant/Board.tsx
@@ -77,7 +77,7 @@ const ApplicantBoard = ({ generation }: ApplicantBoardProps) => {
 
   return (
     <Board
-      wapperClassname="divide-x"
+      wrapperClassname="divide-x"
       boardData={createSearchData(true) ?? boardData}
       onClick={onClick}
     >

--- a/frontend/components/applicant/Board.tsx
+++ b/frontend/components/applicant/Board.tsx
@@ -59,6 +59,7 @@ const ApplicantBoard = ({ generation }: ApplicantBoardProps) => {
       "name"
     )}`,
     subElements: [
+      `${applicantDataFinder(value, "passState").passState}`,
       `${applicantDataFinder(value, "field1")}/${applicantDataFinder(
         value,
         "field2"

--- a/frontend/components/applicant/Board.tsx
+++ b/frontend/components/applicant/Board.tsx
@@ -81,7 +81,7 @@ const ApplicantBoard = ({ generation }: ApplicantBoardProps) => {
 
   return (
     <Board
-      wrapperClassname="divide-x"
+      wrapperClassName="divide-x"
       boardData={createSearchData(true) ?? boardData}
       onClick={onClick}
     >

--- a/frontend/components/common/board/Board.tsx
+++ b/frontend/components/common/board/Board.tsx
@@ -16,14 +16,14 @@ export interface BoardData {
 
 interface BoardProps extends PropsWithChildren {
   onClick?: (id: string) => void;
-  wrapperClassname?: string;
+  wrapperClassName?: string;
   boardData: BoardData[];
 }
 
 const Board = ({
   children,
   onClick,
-  wrapperClassname,
+  wrapperClassName,
   boardData,
 }: BoardProps) => {
   const { isOpen, openModal, closeModal } = useModalState();
@@ -40,7 +40,7 @@ const Board = ({
         isOpen={isOpen}
         onRequestClose={closeModal}
         ariaHideApp={false}
-        wrapperClassname={wrapperClassname}
+        wrapperClassName={wrapperClassName}
       >
         {children}
       </BoardModal>

--- a/frontend/components/common/board/Board.tsx
+++ b/frontend/components/common/board/Board.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { PropsWithChildren, useState } from "react";
-import BoardCell from "./BoardCell.component";
-import Txt from "../Txt.component";
+import { PropsWithChildren } from "react";
 import useModalState from "../../../src/hooks/useModalState";
 import BoardModal from "./BoardModal";
 import BoardTable from "./BoardTable";

--- a/frontend/components/common/board/Board.tsx
+++ b/frontend/components/common/board/Board.tsx
@@ -7,6 +7,7 @@ import Image from "next/image";
 import CloseImage from "/public/icons/ellipsis.multiply.svg";
 import { cn } from "@/src/utils/cn";
 import Txt from "../Txt.component";
+import useModalState from "../../../src/hooks/useModalState";
 
 interface BoardData {
   id: string;
@@ -21,19 +22,37 @@ interface BoardProps extends PropsWithChildren {
   boardData: BoardData[];
 }
 
+const modalStyle = {
+  content: {
+    width: "calc(100% - 12rem)",
+    zIndex: "9999",
+    height: "calc(100%)",
+    margin: "3rem 6rem 0 6rem",
+    minWidth: "1280px",
+    boxShadow: "0px 0px 6px 1px rgba(0, 0, 0, 0.14)",
+    border: "none",
+    position: "relative",
+    inset: "0",
+    padding: "2.5rem 3rem",
+  },
+  overlay: {
+    padding: "0",
+    position: "absolute",
+  },
+} as const;
+
 const Board = ({
   children,
   onClick,
   wapperClassname,
   boardData,
 }: BoardProps) => {
-  const [isOpen, setIsOpen] = useState(false);
+  const { isOpen, openModal, closeModal } = useModalState();
 
-  const openModel = (id: string) => {
-    setIsOpen(true);
+  const handleModalOpen = (id: string) => () => {
+    openModal();
     onClick && onClick(id);
   };
-  const closeModel = () => setIsOpen(false);
 
   return (
     <section className="flex flex-col">
@@ -46,35 +65,18 @@ const Board = ({
               key={item.id}
               title={item.title}
               subElements={item.subElements}
-              onClick={() => openModel(item.id)}
+              onClick={handleModalOpen(item.id)}
             />
           ))}
         </>
       )}
       <Modal
-        style={{
-          content: {
-            width: "calc(100% - 12rem)",
-            zIndex: "9999",
-            height: "calc(100%)",
-            margin: "3rem 6rem 0 6rem",
-            minWidth: "1280px",
-            boxShadow: "0px 0px 6px 1px rgba(0, 0, 0, 0.14)",
-            border: "none",
-            position: "relative",
-            inset: "0",
-            padding: "2.5rem 3rem",
-          },
-          overlay: {
-            padding: "0",
-            position: "absolute",
-          },
-        }}
+        style={modalStyle}
         isOpen={isOpen}
-        onRequestClose={closeModel}
+        onRequestClose={closeModal}
         ariaHideApp={false}
       >
-        <button className="absolute z-10" onClick={closeModel}>
+        <button className="absolute z-10" onClick={closeModal}>
           <Image src={CloseImage} alt="close" />
         </button>
         <div

--- a/frontend/components/common/board/Board.tsx
+++ b/frontend/components/common/board/Board.tsx
@@ -4,12 +4,14 @@ import { PropsWithChildren } from "react";
 import useModalState from "../../../src/hooks/useModalState";
 import BoardModal from "./BoardModal";
 import BoardTable from "./BoardTable";
+import { type ApplicantPassState } from "../../../src/apis/kanban";
 
 export interface BoardData {
   id: string;
   title: string;
   subElements: string[];
   time?: Date;
+  passState?: ApplicantPassState;
 }
 
 interface BoardProps extends PropsWithChildren {

--- a/frontend/components/common/board/Board.tsx
+++ b/frontend/components/common/board/Board.tsx
@@ -2,14 +2,12 @@
 
 import { PropsWithChildren, useState } from "react";
 import BoardCell from "./BoardCell.component";
-import Modal from "react-modal";
-import Image from "next/image";
-import CloseImage from "/public/icons/ellipsis.multiply.svg";
-import { cn } from "@/src/utils/cn";
 import Txt from "../Txt.component";
 import useModalState from "../../../src/hooks/useModalState";
+import BoardModal from "./BoardModal";
+import BoardTable from "./BoardTable";
 
-interface BoardData {
+export interface BoardData {
   id: string;
   title: string;
   subElements: string[];
@@ -18,33 +16,14 @@ interface BoardData {
 
 interface BoardProps extends PropsWithChildren {
   onClick?: (id: string) => void;
-  wapperClassname?: string;
+  wrapperClassname?: string;
   boardData: BoardData[];
 }
-
-const modalStyle = {
-  content: {
-    width: "calc(100% - 12rem)",
-    zIndex: "9999",
-    height: "calc(100%)",
-    margin: "3rem 6rem 0 6rem",
-    minWidth: "1280px",
-    boxShadow: "0px 0px 6px 1px rgba(0, 0, 0, 0.14)",
-    border: "none",
-    position: "relative",
-    inset: "0",
-    padding: "2.5rem 3rem",
-  },
-  overlay: {
-    padding: "0",
-    position: "absolute",
-  },
-} as const;
 
 const Board = ({
   children,
   onClick,
-  wapperClassname,
+  wrapperClassname,
   boardData,
 }: BoardProps) => {
   const { isOpen, openModal, closeModal } = useModalState();
@@ -55,40 +34,17 @@ const Board = ({
   };
 
   return (
-    <section className="flex flex-col">
-      {boardData.length === 0 ? (
-        <Txt>검색결과가 없습니다.</Txt>
-      ) : (
-        <>
-          {boardData.map((item) => (
-            <BoardCell
-              key={item.id}
-              title={item.title}
-              subElements={item.subElements}
-              onClick={handleModalOpen(item.id)}
-            />
-          ))}
-        </>
-      )}
-      <Modal
-        style={modalStyle}
+    <>
+      <BoardTable boardRows={boardData} handleModalOpen={handleModalOpen} />
+      <BoardModal
         isOpen={isOpen}
         onRequestClose={closeModal}
         ariaHideApp={false}
+        wrapperClassname={wrapperClassname}
       >
-        <button className="absolute z-10" onClick={closeModal}>
-          <Image src={CloseImage} alt="close" />
-        </button>
-        <div
-          className={cn(
-            "flex pt-8 absolute h-[calc(100%-6rem)] w-[calc(100%-6rem)]",
-            wapperClassname
-          )}
-        >
-          {children}
-        </div>
-      </Modal>
-    </section>
+        {children}
+      </BoardModal>
+    </>
   );
 };
 

--- a/frontend/components/common/board/Board.tsx
+++ b/frontend/components/common/board/Board.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { PropsWithChildren } from "react";
+import { type PropsWithChildren } from "react";
 import useModalState from "../../../src/hooks/useModalState";
 import BoardModal from "./BoardModal";
 import BoardTable from "./BoardTable";

--- a/frontend/components/common/board/BoardCell.component.tsx
+++ b/frontend/components/common/board/BoardCell.component.tsx
@@ -1,18 +1,28 @@
+import { type ApplicantPassState } from "../../../src/apis/kanban";
+import PassStateLabel from "../../passState/PassStateLabel";
 import Txt from "../Txt.component";
 
 export interface BoardCellProps {
   title: string;
   subElements: string[];
+  passState?: ApplicantPassState;
   score?: string;
   onClick?: () => void;
 }
 
-const BoardCell = ({ title, subElements, score, onClick }: BoardCellProps) => {
+const BoardCell = ({
+  title,
+  subElements,
+  score,
+  passState,
+  onClick,
+}: BoardCellProps) => {
   return (
     <button className="flex border-t py-4 justify-between" onClick={onClick}>
       <Txt typography="h6" className="flex-[2_0_0] text-left truncate">
         {title}
       </Txt>
+      {passState && <PassStateLabel passState={passState} />}
       <div className="flex gap-20 flex-[2_0_0] text-center truncate">
         {subElements.map((subElement, index) => (
           <Txt

--- a/frontend/components/common/board/BoardModal.tsx
+++ b/frontend/components/common/board/BoardModal.tsx
@@ -1,0 +1,52 @@
+import Modal from "react-modal";
+import CloseImage from "/public/icons/ellipsis.multiply.svg";
+import Image from "next/image";
+import { cn } from "@/src/utils/cn";
+
+const modalStyle = {
+  content: {
+    width: "calc(100% - 12rem)",
+    zIndex: "9999",
+    height: "calc(100%)",
+    margin: "3rem 6rem 0 6rem",
+    minWidth: "1280px",
+    boxShadow: "0px 0px 6px 1px rgba(0, 0, 0, 0.14)",
+    border: "none",
+    position: "relative",
+    inset: "0",
+    padding: "2.5rem 3rem",
+  },
+  overlay: {
+    padding: "0",
+    position: "absolute",
+  },
+} as const;
+
+interface BoardModalProps extends Modal.Props {
+  wrapperClassname?: string;
+}
+
+const BoardModal = ({
+  wrapperClassname,
+  style,
+  children,
+  ...props
+}: BoardModalProps) => {
+  return (
+    <Modal style={{ ...modalStyle, ...style }} {...props}>
+      <button className="absolute z-10" onClick={props.onRequestClose}>
+        <Image src={CloseImage} alt="close" />
+      </button>
+      <div
+        className={cn(
+          "flex pt-8 absolute h-[calc(100%-6rem)] w-[calc(100%-6rem)]",
+          wrapperClassname
+        )}
+      >
+        {children}
+      </div>
+    </Modal>
+  );
+};
+
+export default BoardModal;

--- a/frontend/components/common/board/BoardModal.tsx
+++ b/frontend/components/common/board/BoardModal.tsx
@@ -23,11 +23,11 @@ const modalStyle = {
 } as const;
 
 interface BoardModalProps extends Modal.Props {
-  wrapperClassname?: string;
+  wrapperClassName?: string;
 }
 
 const BoardModal = ({
-  wrapperClassname,
+  wrapperClassName,
   style,
   children,
   ...props
@@ -40,7 +40,7 @@ const BoardModal = ({
       <div
         className={cn(
           "flex pt-8 absolute h-[calc(100%-6rem)] w-[calc(100%-6rem)]",
-          wrapperClassname
+          wrapperClassName
         )}
       >
         {children}

--- a/frontend/components/common/board/BoardTable.tsx
+++ b/frontend/components/common/board/BoardTable.tsx
@@ -13,13 +13,13 @@ const BoardTable = ({ boardRows, handleModalOpen }: BoardTableProps) => {
         <Txt>검색결과가 없습니다.</Txt>
       ) : (
         <>
-          {boardRows.map((item) => (
+          {boardRows.map(({ id, title, subElements, passState }) => (
             <BoardCell
-              key={item.id}
-              title={item.title}
-              subElements={item.subElements}
-              passState={item.passState}
-              onClick={handleModalOpen(item.id)}
+              key={id}
+              title={title}
+              subElements={subElements}
+              passState={passState}
+              onClick={handleModalOpen(id)}
             />
           ))}
         </>

--- a/frontend/components/common/board/BoardTable.tsx
+++ b/frontend/components/common/board/BoardTable.tsx
@@ -1,0 +1,30 @@
+import Txt from "../Txt.component";
+import { BoardData } from "./Board";
+import BoardCell from "./BoardCell.component";
+
+interface BoardTableProps {
+  boardRows: BoardData[];
+  handleModalOpen: (id: string) => () => void;
+}
+const BoardTable = ({ boardRows, handleModalOpen }: BoardTableProps) => {
+  return (
+    <section className="flex flex-col">
+      {boardRows.length === 0 ? (
+        <Txt>검색결과가 없습니다.</Txt>
+      ) : (
+        <>
+          {boardRows.map((item) => (
+            <BoardCell
+              key={item.id}
+              title={item.title}
+              subElements={item.subElements}
+              onClick={handleModalOpen(item.id)}
+            />
+          ))}
+        </>
+      )}
+    </section>
+  );
+};
+
+export default BoardTable;

--- a/frontend/components/common/board/BoardTable.tsx
+++ b/frontend/components/common/board/BoardTable.tsx
@@ -18,6 +18,7 @@ const BoardTable = ({ boardRows, handleModalOpen }: BoardTableProps) => {
               key={item.id}
               title={item.title}
               subElements={item.subElements}
+              passState={item.passState}
               onClick={handleModalOpen(item.id)}
             />
           ))}

--- a/frontend/components/interview/Board.tsx
+++ b/frontend/components/interview/Board.tsx
@@ -73,7 +73,7 @@ const InterviewBoard = ({ generation }: InterviewBoardProps) => {
 
   return (
     <Board
-      wrapperClassname="divide-x"
+      wrapperClassName="divide-x"
       boardData={createSearchData() ?? boardData}
       onClick={(id) => onClick(id)}
     >

--- a/frontend/components/interview/Board.tsx
+++ b/frontend/components/interview/Board.tsx
@@ -8,8 +8,9 @@ import { useAtom } from "jotai";
 import { interViewApplicantIdState } from "@/src/stores/interview/Interview.atom";
 import { useSearchParams } from "next/navigation";
 import { getInterviewRecordByPageWithOrder } from "@/src/apis/interview";
-import { ORDER_MENU } from "@/src/constants";
+import { CHARACTERS, ORDER_MENU } from "@/src/constants";
 import { useSearchQuery } from "@/src/hooks/useSearchQuery";
+import { removeAll } from "@/src/functions/replacer";
 
 interface InterviewBoardProps {
   generation: string;
@@ -55,11 +56,14 @@ const InterviewBoard = ({ generation }: InterviewBoardProps) => {
       id: value.applicantId,
       title: value.name,
       subElements: [
-        value.field1.split('"').join(""),
-        value.field2.split('"').join(""),
-        `${value.grade.split('"').join("")} ${value.semester
-          .split('"')
-          .join("")}`,
+        removeAll(value.field1, CHARACTERS.DOUBLE_QUOTE).concat(
+          CHARACTERS.SLASH,
+          removeAll(value.field2, CHARACTERS.DOUBLE_QUOTE)
+        ),
+        removeAll(value.grade, CHARACTERS.DOUBLE_QUOTE).concat(
+          CHARACTERS.SPACE,
+          removeAll(value.semester, CHARACTERS.DOUBLE_QUOTE)
+        ),
       ],
     };
   });

--- a/frontend/components/interview/Board.tsx
+++ b/frontend/components/interview/Board.tsx
@@ -67,6 +67,7 @@ const InterviewBoard = ({ generation }: InterviewBoardProps) => {
           removeAll(value.semester, CHARACTERS.DOUBLE_QUOTE)
         ),
       ],
+      passState: value.state.passState,
     };
   });
 

--- a/frontend/components/interview/Board.tsx
+++ b/frontend/components/interview/Board.tsx
@@ -70,7 +70,7 @@ const InterviewBoard = ({ generation }: InterviewBoardProps) => {
 
   return (
     <Board
-      wapperClassname="divide-x"
+      wrapperClassname="divide-x"
       boardData={createSearchData() ?? boardData}
       onClick={(id) => onClick(id)}
     >

--- a/frontend/components/interview/Board.tsx
+++ b/frontend/components/interview/Board.tsx
@@ -35,7 +35,7 @@ const InterviewBoard = ({ generation }: InterviewBoardProps) => {
     });
   };
 
-  const { data, isLoading } = useQuery({
+  const { data, status } = useQuery({
     queryKey: ["allInterviewRecord", pageIndex, order, generation],
     queryFn: () =>
       getInterviewRecordByPageWithOrder({
@@ -45,13 +45,15 @@ const InterviewBoard = ({ generation }: InterviewBoardProps) => {
       }),
   });
 
-  if (!data || isLoading) {
+  if (status === "loading") {
     return <div>loading...</div>;
   }
 
-  const { records } = data;
+  if (status === "error") {
+    return <div>에러가 발생하였습니다. 잠시 후 다시 시도해보세요.</div>;
+  }
 
-  const boardData = records.map((value) => {
+  const boardData = data.records.map((value) => {
     return {
       id: value.applicantId,
       title: value.name,

--- a/frontend/components/passState/PassStateLabel.tsx
+++ b/frontend/components/passState/PassStateLabel.tsx
@@ -1,0 +1,27 @@
+import { ApplicantPassState } from "../../src/apis/kanban";
+import { getApplicantPassState } from "../../src/functions/formatter";
+import Txt from "../common/Txt.component";
+
+interface PassStateLabelProps {
+  passState: ApplicantPassState;
+}
+
+// TODO: if you want more reusable component, it's should get addtional prop that custom css style.
+const PassStateLabel = ({ passState }: PassStateLabelProps) => {
+  return (
+    <Txt
+      className="w-full flex-1 last:text-right truncate"
+      color={
+        passState === "non-passed"
+          ? "red"
+          : passState === "final-passed"
+          ? "blue"
+          : "black"
+      }
+    >
+      {getApplicantPassState(passState)}
+    </Txt>
+  );
+};
+
+export default PassStateLabel;

--- a/frontend/src/apis/interview/index.ts
+++ b/frontend/src/apis/interview/index.ts
@@ -1,5 +1,6 @@
 import { https } from "@/src/functions/axios";
 import { PageInfo } from "../applicant";
+import { type ApplicantPassState } from "../kanban";
 
 export interface RecordsRes {
   applicantId: string;
@@ -12,6 +13,10 @@ export interface RecordsRes {
   grade: string;
   semester: string;
   modifiedAt: string;
+  // TODO: 더 범용적이고 재사용 가능하게 타입 선언이 필요함.
+  state: {
+    passState: ApplicantPassState;
+  };
 }
 
 interface RecordsByPageRes {

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -177,3 +177,9 @@ export const needValidatePath = [
 ];
 
 export const MAX_TEXT_LENGTH = 1000;
+
+export const CHARACTERS = {
+  DOUBLE_QUOTE: '"',
+  SLASH: "/",
+  SPACE: " ",
+};

--- a/frontend/src/functions/replacer.ts
+++ b/frontend/src/functions/replacer.ts
@@ -39,3 +39,6 @@ export const replacer = (value: string, type: ReplacerType) => {
 
 export const replaceTwoString = (original: number, by: string = "0") =>
   original.toString().padStart(2, by);
+
+export const removeAll = (str: string, pattern: string | RegExp) =>
+  str.replaceAll(pattern, "");

--- a/frontend/src/hooks/useModalState.ts
+++ b/frontend/src/hooks/useModalState.ts
@@ -1,0 +1,13 @@
+import { useState } from "react";
+
+const useModalState = (initState = false) => {
+  const [isOpen, setIsOpen] = useState(initState);
+
+  return {
+    isOpen,
+    openModal: () => setIsOpen(true),
+    closeModal: () => setIsOpen(false),
+  };
+};
+
+export default useModalState;

--- a/frontend/src/hooks/useSearchQuery.tsx
+++ b/frontend/src/hooks/useSearchQuery.tsx
@@ -18,6 +18,7 @@ export const useSearchQuery = (pageIndex: string) => {
 
   const searchEndPage = search?.endPage;
 
+  // TODO: Search는 대대적인 개편이 들어갈 예정이라, 따로 passState에 대한 처리를 하지 않음.
   const createSearchData = (isIncludeUploadDate = false) => {
     return search?.answers?.map((value) => {
       const searchInterviewData = {

--- a/frontend/src/hooks/useSearchQuery.tsx
+++ b/frontend/src/hooks/useSearchQuery.tsx
@@ -1,6 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { useSearchParams } from "next/navigation";
 import { getSearchTerm } from "@/src/apis/search";
+import { removeAll } from "../functions/replacer";
+import { CHARACTERS } from "@/src/constants";
+
+const { DOUBLE_QUOTE, SLASH, SPACE } = CHARACTERS;
 
 export const useSearchQuery = (pageIndex: string) => {
   const searchParams = useSearchParams();
@@ -20,11 +24,14 @@ export const useSearchQuery = (pageIndex: string) => {
         id: value.id,
         title: `[${value.field}] ${value.name}`,
         subElements: [
-          value.field1.split('"').join(""),
-          value.field2.split('"').join(""),
-          `${value.grade.split('"').join("")} ${value.semester
-            .split('"')
-            .join("")}`,
+          removeAll(value.field1, DOUBLE_QUOTE).concat(
+            SLASH,
+            removeAll(value.field2, DOUBLE_QUOTE)
+          ),
+          removeAll(value.grade, DOUBLE_QUOTE).concat(
+            SPACE,
+            removeAll(value.semester, DOUBLE_QUOTE)
+          ),
         ],
       };
 


### PR DESCRIPTION
## 주요 변경사항
- #203 지원현황 목록 페이지에서 합불상태를 조회할 수 있다.
- #204 면접기록 목록 페이지에서 합불상태를 조회할 수 있다.
<img width="1680" alt="Screenshot 2024-09-18 at 20 32 08" src="https://github.com/user-attachments/assets/1b1fa9c5-0d1d-4945-a1d2-7ba315a45058"> 
<img width="1680" alt="Screenshot 2024-09-18 at 20 32 16" src="https://github.com/user-attachments/assets/e66f0f80-d4fe-4994-b5de-b085c1becd79">

## 리뷰어에게...
- 지원현황/면접기록 페이지가 동일한 컴포넌트를 공유하고 있어서, 편의상 같은 브랜치에서 작업한 점 양해부탁드립니다.
- 기존 컴포넌트를 리팩토링하였습니다.
- 합불상태를 보여주는 Txt 컴포넌트는 #205 를 참고해 만들었습니다. 추후 원하신다면 재사용가능한 컴포넌트로 두루 사용하게 해도 괜찮을듯합니다.

## 관련 이슈

- closes #203 
- closes #204 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [x] `milestone` 설정
