### PR TITLE
fix: 지원서 현황 페이지에서 사용자의 이름 정보가 보이지 않는 버그

### DIFF
--- a/frontend/components/applicant/Board.tsx
+++ b/frontend/components/applicant/Board.tsx
@@ -3,7 +3,6 @@
 import Board from "@/components/common/board/Board";
 import { getApplicantByPageWithGeneration } from "@/src/apis/applicant";
 import ApplicantDetailRight from "./DetailRight.component";
-import ApplicantDetailLeft from "./DetailLeft.component";
 import { useState } from "react";
 import { ApplicantReq } from "@/src/apis/application";
 import { applicantDataFinder } from "@/src/functions/finder";
@@ -12,6 +11,8 @@ import { useSearchParams } from "next/navigation";
 import { ORDER_MENU } from "@/src/constants";
 import { useSearchQuery } from "@/src/hooks/useSearchQuery";
 import { type ApplicantPassState } from "../../src/apis/kanban";
+import ApplicantDetailLeft from "./_applicant/ApplicantDetailLeft";
+import { findApplicantState } from "@/src/utils/applicant";
 
 interface ApplicantBoardProps {
   generation: string;
@@ -74,9 +75,10 @@ const ApplicantBoard = ({ generation }: ApplicantBoardProps) => {
             Number(applicantDataFinder(value, "uploadDate"))
           ).toLocaleString("ko-KR", { dateStyle: "short" }),
     ],
-    passState: `${
-      applicantDataFinder(value, "passState").passState
-    }` as ApplicantPassState,
+    passState: `${applicantDataFinder(
+      value,
+      "passState"
+    )}` as ApplicantPassState,
   }));
 
   return (

--- a/frontend/components/applicant/_applicant/ApplicantDetailLeft.tsx
+++ b/frontend/components/applicant/_applicant/ApplicantDetailLeft.tsx
@@ -4,8 +4,8 @@ import { ApplicantReq } from "@/src/apis/applicant";
 import CustomResource from "./_applicantNode/CustomResource";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  postApplicantPassState,
-  PostApplicantPassStateParams,
+  patchApplicantPassState,
+  PatchApplicantPassStateParams,
 } from "@/src/apis/passState";
 import { applicantDataFinder } from "@/src/functions/finder";
 import { getMyInfo } from "@/src/apis/interview";
@@ -20,8 +20,8 @@ interface DetailLeftProps {
 const ApplicantDetailLeft = ({ data, cardId, generation }: DetailLeftProps) => {
   const queryClient = useQueryClient();
   const { mutate: updateApplicantPassState } = useMutation({
-    mutationFn: (params: PostApplicantPassStateParams) =>
-      postApplicantPassState(params),
+    mutationFn: (params: PatchApplicantPassStateParams) =>
+      patchApplicantPassState(params),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [

--- a/frontend/components/applicant/_applicant/ApplicantDetailLeft.tsx
+++ b/frontend/components/applicant/_applicant/ApplicantDetailLeft.tsx
@@ -57,7 +57,10 @@ const ApplicantDetailLeft = ({ data, cardId, generation }: DetailLeftProps) => {
     <>
       <CustomResource
         data={data}
-        ableToEdit={userData?.role === "ROLE_OPERATION"}
+        ableToEdit={
+          userData?.role === "ROLE_OPERATION" ||
+          userData?.role === "ROLE_PRESIDENT"
+        }
         onClickPass={onClickPass}
         onClickNonPass={onClickNonPass}
       />

--- a/frontend/components/applicant/_applicant/ApplicantDetailLeft.tsx
+++ b/frontend/components/applicant/_applicant/ApplicantDetailLeft.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { ApplicantReq } from "@/src/apis/applicant";
+import CustomResource from "./_applicantNode/CustomResource";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  postApplicantPassState,
+  PostApplicantPassStateParams,
+} from "@/src/apis/passState";
+import { applicantDataFinder } from "@/src/functions/finder";
+import { getMyInfo } from "@/src/apis/interview";
+import ApplicantLabel from "../applicantNode/Label.component";
+import ApplicantComment from "../applicantNode/comment/Comment.component";
+
+interface DetailLeftProps {
+  data: ApplicantReq[];
+  generation: string;
+  cardId: number;
+}
+const ApplicantDetailLeft = ({ data, cardId, generation }: DetailLeftProps) => {
+  const queryClient = useQueryClient();
+  const { mutate: updateApplicantPassState } = useMutation({
+    mutationFn: (params: PostApplicantPassStateParams) =>
+      postApplicantPassState(params),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [
+          "allApplicantsWithPassState",
+          applicantDataFinder(data, "generation"),
+        ],
+      });
+    },
+  });
+  const { data: userData } = useQuery(["user"], getMyInfo);
+
+  const postId = applicantDataFinder(data, "id");
+
+  const onClickPass = () => {
+    const ok = confirm("합격 처리하시겠습니까?");
+    if (!ok) return;
+    updateApplicantPassState({
+      applicantId: postId,
+      afterState: "pass",
+    });
+  };
+
+  const onClickNonPass = () => {
+    const ok = confirm("불합격 처리하시겠습니까?");
+    if (!ok) return;
+    updateApplicantPassState({
+      applicantId: postId,
+      afterState: "non-pass",
+    });
+  };
+
+  return (
+    <>
+      <CustomResource
+        data={data}
+        ableToEdit={userData?.role === "ROLE_OPERATION"}
+        onClickPass={onClickPass}
+        onClickNonPass={onClickNonPass}
+      />
+      <ApplicantLabel postId={postId} generation={generation} />
+      <ApplicantComment
+        cardId={cardId}
+        postId={postId}
+        generation={generation}
+      />
+    </>
+  );
+};
+
+export default ApplicantDetailLeft;

--- a/frontend/components/applicant/_applicant/_applicantNode/CustomResource.tsx
+++ b/frontend/components/applicant/_applicant/_applicantNode/CustomResource.tsx
@@ -1,0 +1,80 @@
+import { applicantDataFinder } from "@/src/functions/finder";
+import Portfolio from "../../applicantNode/Portfolio";
+import { ApplicantReq } from "@/src/apis/applicant";
+import Txt from "@/components/common/Txt.component";
+import { getApplicantPassState } from "@/src/functions/formatter";
+
+interface CustomResourceProps {
+  data: ApplicantReq[];
+  ableToEdit?: boolean;
+  onClickPass?: () => void;
+  onClickNonPass?: () => void;
+}
+
+const CustomResource = ({
+  data,
+  ableToEdit = false,
+  onClickPass,
+  onClickNonPass,
+}: CustomResourceProps) => {
+  return (
+    <>
+      <div className="flex flex-col gap-1 mb-2">
+        <Txt className="text-xl text-secondary-200 font-medium">
+          {applicantDataFinder(data, "major")}
+        </Txt>
+        <div className="flex gap-8 items-center">
+          <Txt typography="h2">{`[${applicantDataFinder(
+            data,
+            "field"
+          )}] ${applicantDataFinder(data, "name")}`}</Txt>
+          <div className="flex justify-between grow items-center">
+            <Txt typography="h5" color="light_gray" className="truncate">
+              {getApplicantPassState(applicantDataFinder(data, "passState")) ||
+                "에러 발생"}
+            </Txt>
+            {ableToEdit && (
+              <div className="flex gap-4">
+                <button
+                  className="border rounded-lg px-4 py-2 truncate hover:bg-primary-100"
+                  onClick={onClickPass}
+                >
+                  합격
+                </button>
+                <button
+                  className="border rounded-lg px-4 py-2 truncate hover:bg-primary-100"
+                  onClick={onClickNonPass}
+                >
+                  불합격
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="flex gap-4 mb-8">
+        <div className="flex gap-1">
+          <Txt typography="h3" color="gray" className="font-normal">
+            1지망:
+          </Txt>
+          <Txt typography="h3" color="blue">
+            {applicantDataFinder(data, "field1")}
+          </Txt>
+        </div>
+        <div className="flex gap-1">
+          <Txt typography="h3" color="gray" className="font-normal">
+            2지망:
+          </Txt>
+          <Txt typography="h3" color="blue">
+            {applicantDataFinder(data, "field2")}
+          </Txt>
+        </div>
+      </div>
+      <div className="flex flex-col gap-4">
+        <Portfolio data={data} />
+      </div>
+    </>
+  );
+};
+
+export default CustomResource;

--- a/frontend/components/passState/ApplicantsList.tsx
+++ b/frontend/components/passState/ApplicantsList.tsx
@@ -2,7 +2,7 @@
 
 import {
   getAllApplicantsWithPassState,
-  postApplicantPassState,
+  patchApplicantPassState,
 } from "@/src/apis/passState";
 import { CURRENT_GENERATION } from "@/src/constants";
 import { usePathname } from "next/navigation";
@@ -10,7 +10,7 @@ import Txt from "../common/Txt.component";
 import { getApplicantPassState } from "@/src/functions/formatter";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type {
-  PostApplicantPassStateParams,
+  PatchApplicantPassStateParams,
   Answer,
 } from "@/src/apis/passState";
 
@@ -57,8 +57,8 @@ const ApplicantsList = ({ sortedBy }: ApplicantsListProps) => {
   );
 
   const { mutate: updateApplicantPassState } = useMutation({
-    mutationFn: (params: PostApplicantPassStateParams) =>
-      postApplicantPassState(params),
+    mutationFn: (params: PatchApplicantPassStateParams) =>
+      patchApplicantPassState(params),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ["allApplicantsWithPassState", selectedGeneration],
@@ -86,7 +86,7 @@ const ApplicantsList = ({ sortedBy }: ApplicantsListProps) => {
 
   const onChangeApplicantsPassState = (
     applicantName: string,
-    params: PostApplicantPassStateParams
+    params: PatchApplicantPassStateParams
   ) => {
     const ok = confirm(
       `${applicantName}님을 ${params.afterState} 처리하시겠습니까?`

--- a/frontend/components/passState/ApplicantsList.tsx
+++ b/frontend/components/passState/ApplicantsList.tsx
@@ -132,7 +132,7 @@ const ApplicantsList = ({ sortedBy }: ApplicantsListProps) => {
                 className="border px-4 py-2 rounded-lg truncate hover:bg-primary-100"
                 onClick={() =>
                   onChangeApplicantsPassState(name, {
-                    applicantsId: id,
+                    applicantId: id,
                     afterState: "pass",
                   })
                 }
@@ -143,7 +143,7 @@ const ApplicantsList = ({ sortedBy }: ApplicantsListProps) => {
                 className="border px-4 rounded-lg truncate hover:bg-primary-100"
                 onClick={() =>
                   onChangeApplicantsPassState(name, {
-                    applicantsId: id,
+                    applicantId: id,
                     afterState: "non-pass",
                   })
                 }

--- a/frontend/src/apis/applicant/index.ts
+++ b/frontend/src/apis/applicant/index.ts
@@ -12,6 +12,46 @@ interface AllApplicantReq {
   [string: string]: string;
 }
 
+interface ApplicantByPageReqAnswer {
+  field: string;
+  field1: string;
+  field2: string;
+  name: string;
+  contacted: string;
+  classOf: string;
+  registered: string;
+  grade: string;
+  semester: string;
+  major: string;
+  doubleMajor: string;
+  minor: string;
+  activity: string;
+  reason: string;
+  future: string;
+  experience: string;
+  experienceTextarea: string;
+  restoration: string;
+  deep: string;
+  collaboration: string;
+  studyPlan: string;
+  portfolio: string;
+  fileUrl: string;
+  email: string;
+  check: string;
+  personalInformationAgree: string;
+  personalInformationAgreeForPortfolio: string;
+  generation: string;
+  uploadDate: string;
+  channel: string;
+  timeline: number[];
+  id: string;
+  year: number;
+  created_at: string;
+  passState: {
+    passState: ApplicantPassState;
+  };
+}
+
 export const getApplicantByIdWithField = async (
   id: string,
   fields?: string[]
@@ -36,9 +76,29 @@ export interface PageInfo {
   boardLimit: number;
 }
 
+function formatApplicantsDataToApplicantReq(
+  applicants: ApplicantByPageReqAnswer[]
+) {
+  return applicants.map(
+    (applicant) =>
+      Object.keys(applicant).map((key) => {
+        if (key === "passState") {
+          return {
+            name: "passState",
+            answer: applicant.passState.passState,
+          };
+        }
+        return {
+          name: key,
+          answer: applicant[key as keyof ApplicantByPageReqAnswer],
+        };
+      }) as ApplicantReq[]
+  );
+}
+
 interface ApplicantByPageReq {
   pageInfo: PageInfo;
-  answers: AllApplicantReq[];
+  answers: ApplicantByPageReqAnswer[];
 }
 
 export const getApplicantByPageWithGeneration = async (
@@ -54,12 +114,7 @@ export const getApplicantByPageWithGeneration = async (
 
   return {
     maxPage: pageInfo.endPage,
-    applicants: answers.map((applicant) =>
-      Object.keys(applicant).map((key) => ({
-        name: key,
-        answer: applicant[key],
-      }))
-    ),
+    applicants: formatApplicantsDataToApplicantReq(answers),
   };
 };
 

--- a/frontend/src/apis/passState/index.tsx
+++ b/frontend/src/apis/passState/index.tsx
@@ -23,14 +23,12 @@ export const getAllApplicantsWithPassState = async (generation: string) => {
 };
 
 export interface PostApplicantPassStateParams {
-  applicantsId: string;
+  applicantId: string;
   afterState: "non-pass" | "pass";
 }
 export const postApplicantPassState = async ({
   afterState,
-  applicantsId,
+  applicantId,
 }: PostApplicantPassStateParams) => {
-  await https.post(
-    `/applicants/${applicantsId}/state?afterState=${afterState}`
-  );
+  await https.post(`/applicants/${applicantId}/state?afterState=${afterState}`);
 };

--- a/frontend/src/apis/passState/index.tsx
+++ b/frontend/src/apis/passState/index.tsx
@@ -22,13 +22,13 @@ export const getAllApplicantsWithPassState = async (generation: string) => {
   return data;
 };
 
-export interface PostApplicantPassStateParams {
+export interface PatchApplicantPassStateParams {
   applicantId: string;
   afterState: "non-pass" | "pass";
 }
-export const postApplicantPassState = async ({
+export const patchApplicantPassState = async ({
   afterState,
   applicantId,
-}: PostApplicantPassStateParams) => {
+}: PatchApplicantPassStateParams) => {
   await https.post(`/applicants/${applicantId}/state?afterState=${afterState}`);
 };


### PR DESCRIPTION
## 주요 변경사항

기존에 지원 현황 페이지의 사용자 클릭시 올바르게 사용자의 정보가 보이지 않는 버그가 존재하였습니다.

![image](https://github.com/user-attachments/assets/c366cdd8-f88d-4d4e-a84a-3a24ceaf6f43)

이는 같은 ui를 가지는 칸반 디테일 페이지와 지원 현황 디테일 페이지가 다른 비지니스를 가져 발생하였습니다. 

ui 로직을 공통 컴포넌트로 만들어서 이를 해결하고자 하였습니다. 

다만, 여기서는 공통 컴포넌트를 만들기만 하였으며, 적용은 지원 현황 디테일 페이지에만 적용이 되어있습니다.
추후 이슈를 파서 칸반보드 디테일 페이지에도 적용하도록 하겠습니다. 
(현재 파일명에 _가 붙어있는 것은 문제 해결 전의 기존 컴포넌트와 동일한 이름을 가지는 컴포넌트로 만들어 해당 문제를 해결하고자 하였기 때문입니다. 이는 추후 칸반보드 디테일 페이지에도 적용하게 될 때 제거하도록 하겠습니다.)


## 리뷰어에게...
- 코드적인 문제 상황이 있을지 확인 부탁드립니다. 개발용에서는 문제점은 발견되지 않았습니다. 


## 관련 이슈

closes #202 #218 
