### PR TITLE
bug: 지원자의 프로토콜이 붙지 않은 포트폴리오 링크에 대한 버그 수정

### DIFF
--- a/frontend/components/applicant/applicantNode/Portfolio.tsx
+++ b/frontend/components/applicant/applicantNode/Portfolio.tsx
@@ -1,6 +1,7 @@
 import Txt from "@/components/common/Txt.component";
 import { ApplicantReq } from "@/src/apis/applicant";
 import { applicantDataFinder } from "@/src/functions/finder";
+import { changeIntactUrl } from "@/src/utils/applicant";
 import Link from "next/link";
 
 interface PortfolioProps {
@@ -12,15 +13,15 @@ const Portfolio = ({ data }: PortfolioProps) => {
 
   const portfolio = applicantDataFinder(data, "portfolio")
     .split(regex)
-    .map((url: string) => url.trim());
+    .map((url: string) => changeIntactUrl(url.trim()));
 
   const file = applicantDataFinder(data, "fileUrl")
     .split(regex)
-    .map((url: string) => url.trim());
+    .map((url: string) => changeIntactUrl(url.trim()));
 
   const fileUrlForPlanner = applicantDataFinder(data, "fileUrlforPlanner")
     .split(regex)
-    .map((url: string) => url.trim());
+    .map((url: string) => changeIntactUrl(url.trim()));
 
   return (
     <>

--- a/frontend/components/applicant/applicantNode/Portfolio.tsx
+++ b/frontend/components/applicant/applicantNode/Portfolio.tsx
@@ -31,7 +31,12 @@ const Portfolio = ({ data }: PortfolioProps) => {
           <Txt typography="h6">링크</Txt>
           {portfolio.map((url: string, index: number) => {
             return (
-              <Link href={url} target="_blank" key={index}>
+              <Link
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                key={index}
+              >
                 <Txt className="break-all">{url}</Txt>
               </Link>
             );
@@ -41,7 +46,12 @@ const Portfolio = ({ data }: PortfolioProps) => {
           <Txt typography="h6">파일</Txt>
           {file.map((url: string, index: number) => {
             return (
-              <Link href={url} target="_blank" key={index}>
+              <Link
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                key={index}
+              >
                 <Txt className="break-all">{url}</Txt>
               </Link>
             );
@@ -52,7 +62,12 @@ const Portfolio = ({ data }: PortfolioProps) => {
             <Txt typography="h6">이번 학기 프로젝트 기획서</Txt>
             {fileUrlForPlanner.map((url: string, index: number) => {
               return (
-                <Link href={url} target="_blank" key={index}>
+                <Link
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  key={index}
+                >
                   <Txt className="break-all">{url}</Txt>
                 </Link>
               );

--- a/frontend/src/utils/applicant/index.ts
+++ b/frontend/src/utils/applicant/index.ts
@@ -7,3 +7,13 @@ export const findApplicantState = (
   return cardsData.find((card) => card.applicantId === applicantId)?.state
     .passState;
 };
+
+export const changeIntactUrl = (url: string) => {
+  if (!url) return url;
+
+  if (!/^https?:\/\//.test(url)) {
+    return `http://${url}`;
+  }
+
+  return url;
+};


### PR DESCRIPTION
## 주요 변경사항
1. changeIntactUrl 함수 생성 : http 혹은 https 프로토콜이 붙지 않은 url에 대해 http 프로토콜을 붙여준다.
2. Link 태그의 target="_blank"로 인해 발생할 수 있는 보안 문제를 해결하기 위해 rel="noopener noreferrer" 속성 추가

## 리뷰어에게...
프로토콜이 붙지 않은 url에 대해서 http 프로토콜을 붙이도록 함수를 구현했는데 https에 대한 처리는 어떻게 해야할 지 모르겠네요. (https로 접근을 해야하는 사이트인데 http로 접근하면 문제가 발생할 수도 있을 것 같습니다.)

## 관련 이슈

closes #223 
