### PR TITLE
refactor: 프로토콜이 붙지 않은 url에 대해서 프로토콜을 붙여주는 로직 삭제

### DIFF
--- a/frontend/components/applicant/applicantNode/Portfolio.tsx
+++ b/frontend/components/applicant/applicantNode/Portfolio.tsx
@@ -1,7 +1,6 @@
 import Txt from "@/components/common/Txt.component";
 import { ApplicantReq } from "@/src/apis/applicant";
 import { applicantDataFinder } from "@/src/functions/finder";
-import { changeIntactUrl } from "@/src/utils/applicant";
 import Link from "next/link";
 
 interface PortfolioProps {
@@ -13,15 +12,15 @@ const Portfolio = ({ data }: PortfolioProps) => {
 
   const portfolio = applicantDataFinder(data, "portfolio")
     .split(regex)
-    .map((url: string) => changeIntactUrl(url.trim()));
+    .map((url: string) => url.trim());
 
   const file = applicantDataFinder(data, "fileUrl")
     .split(regex)
-    .map((url: string) => changeIntactUrl(url.trim()));
+    .map((url: string) => url.trim());
 
   const fileUrlForPlanner = applicantDataFinder(data, "fileUrlforPlanner")
     .split(regex)
-    .map((url: string) => changeIntactUrl(url.trim()));
+    .map((url: string) => url.trim());
 
   return (
     <>

--- a/frontend/src/utils/applicant/index.ts
+++ b/frontend/src/utils/applicant/index.ts
@@ -7,13 +7,3 @@ export const findApplicantState = (
   return cardsData.find((card) => card.applicantId === applicantId)?.state
     .passState;
 };
-
-export const changeIntactUrl = (url: string) => {
-  if (!url) return url;
-
-  if (!/^https?:\/\//.test(url)) {
-    return `http://${url}`;
-  }
-
-  return url;
-};


### PR DESCRIPTION
## 관련 이슈

- closes #228 

### 작업 분류

- [ ] 버그 수정
- [ ] 신규 기능 추가
- [ ] 프로젝트 구조 변경
- [ ] 코드 스타일 변경
- [x] 기존 기능 개선
- [ ] 문서 수정

## PR을 통해 해결하려는 문제가 무엇인가요? 🚀
기존의 프로토콜이 붙지 않은 url에 대해서 프로토콜을 붙여주는 로직이 모든 예외 사항을 잡아주지 않습니다.
예시는 이슈에 있습니다 !

## PR에서 핵심적으로 변경된 부분이 어떤 부분인가요? 👀

해당 로직을 삭제하였습니다 !

## 이런 부분을 신경써서 봐주셨으면 좋겠어요. 🙋🏻‍♂️

추후에 지원서 작성 시 url을 입력하는 부분의 input을 변경하는게 좋아보입니다.
### 형식
url에 대한 설명 : url 
ex) 노션 : 노션 url

## 체크리스트 ✅

- [x] `reviewers` 설정
- [x] `assignees` 설정
- [x] `label` 설정
