### PR TITLE
refactor: 포트폴리오 URL 입력 형식 변경

### DIFF
--- a/frontend/components/application/Junction.component.tsx
+++ b/frontend/components/application/Junction.component.tsx
@@ -8,6 +8,7 @@ import ApplicationCheckboxWithEtc from "./applicationNode/CheckboxWithEtc.compon
 import ApplicationTextarea from "./applicationNode/Textarea.component";
 import ApplicationBar from "./applicationNode/Bar.component";
 import ApplicationJustText from "./applicationNode/JustText.component";
+import ApplicationAddText from "./applicationNode/AddText";
 
 interface JunctionQuestionProps {
   applicationNodeData: ApplicationNode;
@@ -28,6 +29,7 @@ export const JunctionQuestion = ({
     checkboxWithEtc: <ApplicationCheckboxWithEtc data={applicationNodeData} />,
     checkbox: <></>,
     timeline: <></>,
+    addText: <ApplicationAddText data={applicationNodeData} />,
   };
 
   return jsxNode[applicationNodeData.type];

--- a/frontend/components/application/JunctionOrLayout.tsx
+++ b/frontend/components/application/JunctionOrLayout.tsx
@@ -11,12 +11,10 @@ const checkQuestion = (
   return "id" in node;
 };
 
-// FIXME: 타입 오타 수정 바람 (Junctin -> Junction)
-interface JunctinOrLayoutProps {
+interface JunctionOrLayoutProps {
   node: ApplicationQuestion | ApplicationNode;
 }
-// FIXME: 컴포넌트 오타 수정 바람 (Junctin -> Junction)
-export const JunctinOrLayout = ({ node }: JunctinOrLayoutProps) => {
+export const JunctionOrLayout = ({ node }: JunctionOrLayoutProps) => {
   return checkQuestion(node) ? (
     <ApplicationLayout applicationQuestion={node} />
   ) : (

--- a/frontend/components/application/applicationLayout/Horizontal.componet.tsx
+++ b/frontend/components/application/applicationLayout/Horizontal.componet.tsx
@@ -2,7 +2,7 @@
 
 import Txt from "@/components/common/Txt.component";
 import type { ApplicationQuestion } from "@/src/constants/application/type";
-import { JunctinOrLayout } from "../JunctionOrLayout";
+import { JunctionOrLayout } from "../JunctionOrLayout";
 
 interface ApplicationHorizontalLayoutProps {
   applicationQuestion: ApplicationQuestion;
@@ -36,7 +36,7 @@ const ApplicationHorizontalLayout = ({
       <div className="flex-1">
         {applicationQuestion.nodes.map((node, index) => (
           <div key={`${applicationQuestion.id} ${index}`} className="mb-4">
-            <JunctinOrLayout node={node} />
+            <JunctionOrLayout node={node} />
           </div>
         ))}
       </div>

--- a/frontend/components/application/applicationLayout/Horizontal.componet.tsx
+++ b/frontend/components/application/applicationLayout/Horizontal.componet.tsx
@@ -25,7 +25,7 @@ const ApplicationHorizontalLayout = ({
             <Txt className="text-sm">{applicationQuestion.subtitle}</Txt>
             {applicationQuestion.alert && (
               <div className="mt-4">
-                <Txt className=" underline font-semibold">
+                <Txt className="font-semibold border-b-2 border-solid pb-1 border-black">
                   ⚠️ {applicationQuestion.alert}
                 </Txt>
               </div>

--- a/frontend/components/application/applicationLayout/Vertical.component.tsx
+++ b/frontend/components/application/applicationLayout/Vertical.component.tsx
@@ -2,7 +2,7 @@
 
 import Txt from "@/components/common/Txt.component";
 import type { ApplicationQuestion } from "@/src/constants/application/type";
-import { JunctinOrLayout } from "../JunctionOrLayout";
+import { JunctionOrLayout } from "../JunctionOrLayout";
 import { cn } from "@/src/utils/cn";
 
 interface ApplicationVerticalLayoutProps {
@@ -28,7 +28,7 @@ const ApplicationVerticalLayout = ({
       )}
       {applicationQuestion.nodes.map((node, index) => (
         <div key={index} className="mb-4">
-          <JunctinOrLayout node={node} />
+          <JunctionOrLayout node={node} />
         </div>
       ))}
     </div>

--- a/frontend/components/application/applicationNode/AddText.tsx
+++ b/frontend/components/application/applicationNode/AddText.tsx
@@ -25,7 +25,7 @@ const ApplicationAddText = ({ data }: ApplicationAddTextProps) => {
   const [selectedCategories, setSelectedCategories] = useState<
     { category: string; id: string; value: string }[]
   >(
-    localStorageData.length === 0
+    !localStorageData.length
       ? [{ category: "Github", id, value: "" }]
       : localStorageData
   );

--- a/frontend/components/application/applicationNode/AddText.tsx
+++ b/frontend/components/application/applicationNode/AddText.tsx
@@ -9,19 +9,14 @@ import {
 import { useState } from "react";
 import ApplicationText from "./Text.component";
 import { getLocalStorage } from "@/src/utils/applicant";
+import { portfolioCategory } from "@/src/constants/application";
 
 interface ApplicationAddTextProps {
   data: ApplicationNode;
 }
 
 const ApplicationAddText = ({ data }: ApplicationAddTextProps) => {
-  const localStorageData = getLocalStorage([
-    "Github",
-    "Blog",
-    "Notion",
-    "Website",
-    "기타",
-  ]);
+  const localStorageData = getLocalStorage(portfolioCategory);
 
   const textData = data as ApplicationAddText;
 

--- a/frontend/components/application/applicationNode/AddText.tsx
+++ b/frontend/components/application/applicationNode/AddText.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import Txt from "@/components/common/Txt.component";
+import {
+  type ApplicationAddText,
+  ApplicationNode,
+} from "@/src/constants/application/type";
+
+import { useState } from "react";
+import ApplicationText from "./Text.component";
+
+interface ApplicationAddTextProps {
+  data: ApplicationNode;
+}
+
+const ApplicationAddText = ({ data }: ApplicationAddTextProps) => {
+  const textData = data as ApplicationAddText;
+  const id = Date.now().toString();
+  const [selectedCategories, setSelectedCategories] = useState<
+    { category: string; id: string }[]
+  >([{ category: "Github", id: id }]);
+
+  const onAddCategory = () => {
+    const newId = Date.now().toString();
+
+    setSelectedCategories([
+      ...selectedCategories,
+      { category: "Github", id: newId },
+    ]);
+  };
+
+  return (
+    <>
+      {textData.title && (
+        <div className="flex flex-row justify-between">
+          <label>
+            <Txt typography="h6">{`${textData.title} ${textData.alert}`}</Txt>
+          </label>
+          <button
+            onClick={onAddCategory}
+            className="ml-2 border p-2 rounded-lg"
+          >
+            +추가
+          </button>
+        </div>
+      )}
+      {selectedCategories.map((selectedCategory) => (
+        <ApplicationUrlText
+          selectedCategory={selectedCategory}
+          selectedCategories={selectedCategories}
+          setSelectedCategories={setSelectedCategories}
+          textData={textData}
+          key={selectedCategory.id}
+        />
+      ))}
+    </>
+  );
+};
+
+export default ApplicationAddText;
+
+interface ApplicationUrlTextProps {
+  selectedCategory: { category: string; id: string };
+  selectedCategories: { category: string; id: string }[];
+  setSelectedCategories: (
+    categories: { category: string; id: string }[]
+  ) => void;
+  textData: ApplicationAddText;
+}
+
+const ApplicationUrlText = ({
+  selectedCategory,
+  selectedCategories,
+  setSelectedCategories,
+  textData,
+}: ApplicationUrlTextProps) => {
+  const onCategoryChange = (id: string, value: string) => {
+    const prevCategory = selectedCategory.category;
+    const prevCategoryData = localStorage.getItem(`${prevCategory} - ${id}`);
+    const newCategories = [...selectedCategories];
+
+    localStorage.removeItem(`${prevCategory} - ${id}`);
+
+    newCategories.forEach((category) => {
+      if (category.id === id) {
+        category.category = value;
+      }
+    });
+
+    prevCategoryData &&
+      localStorage.setItem(`${value} - ${id}`, prevCategoryData);
+
+    setSelectedCategories(newCategories);
+  };
+
+  const onRemoveCategory = (
+    id: string,
+    selectedCategory: { category: string; id: string }
+  ) => {
+    const newCategories = selectedCategories.filter(
+      (category) => category.id !== id
+    );
+
+    localStorage.removeItem(`${selectedCategory.category} - ${id}`);
+    setSelectedCategories(newCategories);
+  };
+
+  return (
+    <div className="flex flex-row gap-2 items-center">
+      <select
+        onChange={(e) => onCategoryChange(selectedCategory.id, e.target.value)}
+        className="border my-2 rounded-lg p-4"
+        value={selectedCategory.category}
+      >
+        {textData.category.map((category) => (
+          <option key={category} value={category}>
+            {category}
+          </option>
+        ))}
+      </select>
+      <ApplicationText
+        data={{
+          ...textData,
+          title: "",
+          name: `${selectedCategory.category} - ${selectedCategory.id}`,
+        }}
+      />
+      <button
+        onClick={() => onRemoveCategory(selectedCategory.id, selectedCategory)}
+        className="border rounded-full h-10 my-2 p-2 w-10"
+      >
+        -
+      </button>
+    </div>
+  );
+};

--- a/frontend/components/application/applicationNode/AddText.tsx
+++ b/frontend/components/application/applicationNode/AddText.tsx
@@ -21,9 +21,10 @@ const ApplicationAddText = ({ data }: ApplicationAddTextProps) => {
   const textData = data as ApplicationAddText;
 
   const id = Date.now().toString();
-  const [selectedCategories, setSelectedCategories] = useState<
-    { category: string; id: string; value: string }[]
-  >(localStorageData || [{ category: "Github", id: id, value: "" }]);
+  const [selectedCategories, setSelectedCategories] =
+    useState<{ category: string; id: string; value: string }[]>(
+      localStorageData
+    );
 
   const onAddCategory = () => {
     const newId = Date.now().toString();

--- a/frontend/components/application/applicationNode/AddText.tsx
+++ b/frontend/components/application/applicationNode/AddText.tsx
@@ -21,10 +21,14 @@ const ApplicationAddText = ({ data }: ApplicationAddTextProps) => {
   const textData = data as ApplicationAddText;
 
   const id = Date.now().toString();
-  const [selectedCategories, setSelectedCategories] =
-    useState<{ category: string; id: string; value: string }[]>(
-      localStorageData
-    );
+
+  const [selectedCategories, setSelectedCategories] = useState<
+    { category: string; id: string; value: string }[]
+  >(
+    localStorageData.length === 0
+      ? [{ category: "Github", id, value: "" }]
+      : localStorageData
+  );
 
   const onAddCategory = () => {
     const newId = Date.now().toString();

--- a/frontend/components/application/applicationNode/AddText.tsx
+++ b/frontend/components/application/applicationNode/AddText.tsx
@@ -8,24 +8,34 @@ import {
 
 import { useState } from "react";
 import ApplicationText from "./Text.component";
+import { getLocalStorage } from "@/src/utils/applicant";
 
 interface ApplicationAddTextProps {
   data: ApplicationNode;
 }
 
 const ApplicationAddText = ({ data }: ApplicationAddTextProps) => {
+  const localStorageData = getLocalStorage([
+    "Github",
+    "Blog",
+    "Notion",
+    "Website",
+    "기타",
+  ]);
+
   const textData = data as ApplicationAddText;
+
   const id = Date.now().toString();
   const [selectedCategories, setSelectedCategories] = useState<
-    { category: string; id: string }[]
-  >([{ category: "Github", id: id }]);
+    { category: string; id: string; value: string }[]
+  >(localStorageData || [{ category: "Github", id: id, value: "" }]);
 
   const onAddCategory = () => {
     const newId = Date.now().toString();
 
     setSelectedCategories([
       ...selectedCategories,
-      { category: "Github", id: newId },
+      { category: "Github", id: newId, value: "" },
     ]);
   };
 
@@ -60,10 +70,10 @@ const ApplicationAddText = ({ data }: ApplicationAddTextProps) => {
 export default ApplicationAddText;
 
 interface ApplicationUrlTextProps {
-  selectedCategory: { category: string; id: string };
-  selectedCategories: { category: string; id: string }[];
+  selectedCategory: { category: string; id: string; value: string };
+  selectedCategories: { category: string; id: string; value: string }[];
   setSelectedCategories: (
-    categories: { category: string; id: string }[]
+    categories: { category: string; id: string; value: string }[]
   ) => void;
   textData: ApplicationAddText;
 }

--- a/frontend/components/application/applicationNode/Text.component.tsx
+++ b/frontend/components/application/applicationNode/Text.component.tsx
@@ -22,7 +22,7 @@ const ApplicationText = ({ data }: ApplicationTextProps) => {
   const [isError, setIsError] = useState(false);
 
   return (
-    <div className="relative">
+    <div className="relative w-full">
       {textData.title && (
         <label>
           <Txt typography="h6">{`${textData.title}${

--- a/frontend/src/constants/application/28/developer.ts
+++ b/frontend/src/constants/application/28/developer.ts
@@ -132,18 +132,12 @@ export const APPLICATION_DEVELOPER: ApplicationQuestion[] = [
     direction: "horizontal",
     nodes: [
       {
+        type: "addText",
         name: "portfolio",
         require: false,
-        type: "text",
         title: "참고 URL",
-        subtitle: "Github, Blog, Notion, Website 등",
-      },
-      {
-        name: "fileUrl",
-        require: false,
-        type: "text",
-        title: "파일 URL",
-        subtitle: "Google Drive 등",
+        category: ["Github", "Blog", "Notion", "Website", "기타"],
+        alert: "(입력창 하나당 하나의 URL을 입력해주세요.)",
       },
     ],
   },

--- a/frontend/src/constants/application/index.ts
+++ b/frontend/src/constants/application/index.ts
@@ -1,0 +1,7 @@
+export const portfolioCategory = [
+  "Github",
+  "Blog",
+  "Notion",
+  "Website",
+  "기타",
+] as const;

--- a/frontend/src/constants/application/type.d.ts
+++ b/frontend/src/constants/application/type.d.ts
@@ -41,6 +41,12 @@ interface ApplicationText extends ApplicationNodeBase {
   minLength?: number;
 }
 
+interface ApplicationAddText extends ApplicationNodeBase {
+  type: "addText";
+  category: ("Github" | "Blog" | "Notion" | "Website" | "기타")[];
+  alert: string;
+}
+
 interface ApplicationTextarea extends ApplicationNodeBase {
   type: "textarea";
 }
@@ -103,7 +109,8 @@ type ApplicationNode =
   | ApplicationJustText
   | ApplicationCheckboxType
   | ApplicationCheckboxWithEtcType
-  | ApplicationTimelineType;
+  | ApplicationTimelineType
+  | ApplicationAddText;
 
 type ApplicationQuestion = {
   id: number;

--- a/frontend/src/constants/application/type.d.ts
+++ b/frontend/src/constants/application/type.d.ts
@@ -1,5 +1,6 @@
 import { ReplacerType } from "@/src/functions/replacer";
 import { ValidatorType } from "@/src/functions/validator";
+import { portfolioCategory } from ".";
 
 interface ApplicationNodeBase {
   title?: string;
@@ -43,7 +44,7 @@ interface ApplicationText extends ApplicationNodeBase {
 
 interface ApplicationAddText extends ApplicationNodeBase {
   type: "addText";
-  category: ("Github" | "Blog" | "Notion" | "Website" | "기타")[];
+  category: (typeof portfolioCategory)[number][];
   alert: string;
 }
 

--- a/frontend/src/hooks/useApplication.tsx
+++ b/frontend/src/hooks/useApplication.tsx
@@ -17,6 +17,7 @@ import {
   applicationDataAtom,
   applicationIndexAtom,
 } from "../stores/application";
+import { getLocalStorage } from "../utils/applicant";
 
 export const useApplication = () => {
   // TODO: 질문의 이름마다 side effect가 있으니 주의하면 좋을 것
@@ -130,6 +131,21 @@ export const useApplication = () => {
     sendValues.push({
       name: "timeline",
       answer: JSON.stringify(timeline),
+    });
+
+    const portfolioUrls = getLocalStorage([
+      "Github",
+      "Blog",
+      "Notion",
+      "Website",
+      "기타",
+    ]);
+
+    portfolioUrls.forEach((portfolioUrl) => {
+      sendValues.push({
+        name: `${portfolioUrl.category} - ${portfolioUrl.id}`,
+        answer: JSON.parse(portfolioUrl.value),
+      });
     });
 
     const applicationName = Array.from(

--- a/frontend/src/hooks/useApplication.tsx
+++ b/frontend/src/hooks/useApplication.tsx
@@ -18,6 +18,7 @@ import {
   applicationIndexAtom,
 } from "../stores/application";
 import { getLocalStorage } from "../utils/applicant";
+import { portfolioCategory } from "../constants/application";
 
 export const useApplication = () => {
   // TODO: 질문의 이름마다 side effect가 있으니 주의하면 좋을 것
@@ -133,13 +134,7 @@ export const useApplication = () => {
       answer: JSON.stringify(timeline),
     });
 
-    const portfolioUrls = getLocalStorage([
-      "Github",
-      "Blog",
-      "Notion",
-      "Website",
-      "기타",
-    ]);
+    const portfolioUrls = getLocalStorage(portfolioCategory);
 
     portfolioUrls.forEach(({ category, id, value }) => {
       sendValues.push({

--- a/frontend/src/hooks/useApplication.tsx
+++ b/frontend/src/hooks/useApplication.tsx
@@ -141,10 +141,10 @@ export const useApplication = () => {
       "기타",
     ]);
 
-    portfolioUrls.forEach((portfolioUrl) => {
+    portfolioUrls.forEach(({ category, id, value }) => {
       sendValues.push({
-        name: `${portfolioUrl.category} - ${portfolioUrl.id}`,
-        answer: JSON.parse(portfolioUrl.value),
+        name: `${category} - ${id}`,
+        answer: JSON.parse(value),
       });
     });
 

--- a/frontend/src/utils/applicant/index.ts
+++ b/frontend/src/utils/applicant/index.ts
@@ -10,26 +10,20 @@ export const findApplicantState = (
 };
 
 export const getLocalStorage = (category: typeof portfolioCategory) => {
-  const data = [];
-
-  for (let i = 0; i < localStorage.length; i++) {
-    const key = localStorage.key(i);
-
-    if (key && category.some((cat) => key.includes(cat))) {
-      const value = localStorage.getItem(key);
-
+  const data = Object.keys(localStorage)
+    .filter((key) =>
+      category.some((cat) => key.includes(cat) && key.includes(" - "))
+    )
+    .map((key) => {
+      const value = localStorage.getItem(key) || "";
       const parts = key.split(" - ");
-      if (parts.length === 2) {
-        const category = parts[0];
-        const id = parts[1];
-        data.push({
-          category,
-          id,
-          value: value || "",
-        });
-      }
-    }
-  }
+
+      return {
+        category: parts[0],
+        id: parts[1],
+        value,
+      };
+    });
 
   return data;
 };

--- a/frontend/src/utils/applicant/index.ts
+++ b/frontend/src/utils/applicant/index.ts
@@ -1,4 +1,5 @@
 import { KanbanCardReq } from "@/src/apis/kanban";
+import { portfolioCategory } from "@/src/constants/application";
 
 export const findApplicantState = (
   cardsData: KanbanCardReq[],
@@ -8,7 +9,7 @@ export const findApplicantState = (
     .passState;
 };
 
-export const getLocalStorage = (category: string[]) => {
+export const getLocalStorage = (category: typeof portfolioCategory) => {
   const data = [];
 
   for (let i = 0; i < localStorage.length; i++) {

--- a/frontend/src/utils/applicant/index.ts
+++ b/frontend/src/utils/applicant/index.ts
@@ -7,3 +7,28 @@ export const findApplicantState = (
   return cardsData.find((card) => card.applicantId === applicantId)?.state
     .passState;
 };
+
+export const getLocalStorage = (category: string[]) => {
+  const data = [];
+
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+
+    if (key && category.some((cat) => key.includes(cat))) {
+      const value = localStorage.getItem(key);
+
+      const parts = key.split(" - ");
+      if (parts.length === 2) {
+        const category = parts[0];
+        const id = parts[1];
+        data.push({
+          category,
+          id,
+          value: value || "",
+        });
+      }
+    }
+  }
+
+  return data;
+};


### PR DESCRIPTION
## 관련 이슈

- closes #230 

### 작업 분류

- [ ] 버그 수정
- [ ] 신규 기능 추가
- [ ] 프로젝트 구조 변경
- [ ] 코드 스타일 변경
- [x] 기존 기능 개선
- [ ] 문서 수정

## PR을 통해 해결하려는 문제가 무엇인가요? 🚀

- 기존 입력창 
![image](https://github.com/user-attachments/assets/4b7defba-fc1c-4887-851b-e85f0ac0257e)

기존 URL 입력 창으로 입력을 받을 시 하나의 input에 여러 개의 주소를 적는 경우가 있었습니다.
이렇게 되면 칸반보드 상세 페이지에서 사용자의 링크를 볼 때 불편함이 있었습니다.

## PR에서 핵심적으로 변경된 부분이 어떤 부분인가요? 👀

- 변경된 입력창 
![image](https://github.com/user-attachments/assets/2fd55b13-6e7d-44a2-98d3-7f99dc380cc0)

- 사용자가 input을 원하는 만큼 만들 수 있고 삭제할 수 있습니다.
- 드롭다운으로 원하는 포트폴리오 유형을 선택할 수 있습니다.

## 추가적으로, 리뷰어가 리뷰하며 알아야 할 정보가 있나요? 🙌

- 테스트를 위해서 28기 개발자의 데이터만 변경하였습니다. (28/developer.ts)
- 신청 페이지에서 작성된 내용은 로컬 스토리지에 저장하기 때문에 key가 중복이 되면 안돼서 현재 시간 값을 사용하여 고유하게 만들었습니다.
## 이런 부분을 신경써서 봐주셨으면 좋겠어요. 🙋🏻‍♂️

<!---
  문제를 해결하며 궁금했던 점, 리뷰어와 같이 이야기 나눠보고 싶은 점
--->

- 제목 부분에 하나의 input에 하나의 링크만 입력하라고 명시해두긴 했는데 validation까지 하는게 좋을까요? (한다면 http가 2번 입력되면 오류 메시지를 띄울려고 하는데 괜찮은 방법인지? 그리고 더 검사할 사항이 있는지 궁금합니다.)
- 포트폴리오 유형을 기타를 클릭하였을 때 input을 하나 더 만들어서 기타가 구체적으로 어떤 것인지 입력 받는게 좋을까요?

## 체크리스트 ✅

- [x] `reviewers` 설정
- [x] `assignees` 설정
- [x] `label` 설정
