### PR TITLE
bug: 비밀 번호 유효성 검사 수정

### DIFF
--- a/frontend/app/signin/page.tsx
+++ b/frontend/app/signin/page.tsx
@@ -31,6 +31,7 @@ const SignInPage = () => {
 
   const onSubmit = async () => {
     if (await signIn(signInData)) {
+      setError("");
       navigate.push("/");
       return;
     }

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -39,7 +39,8 @@ const SignUpPage = () => {
         year: +signUpData.generation,
       })
     ) {
-      navigate.push("/");
+      setError("");
+      navigate.push("/signin");
       alert("회원가입이 완료되었습니다.");
     }
     setError("회원가입이 실패했습니다.");

--- a/frontend/components/user/SignInForm.component.tsx
+++ b/frontend/components/user/SignInForm.component.tsx
@@ -70,7 +70,7 @@ const SignInForm = ({ onSubmit, data, setForm }: SignInProps) => {
         onChange={(e) => setForm({ name: "password", value: e.target.value })}
         isWrong={isWarning.password}
         wrongMessage={
-          "비밀번호는 10자이상, 숫자 최소 1자 이상, 특수문자 최소 1자 이상이어야 합니다."
+          "비밀번호는 10자 이상이어야 하며, 최소 1개의 숫자와 1개의 특수문자를 포함해야 합니다."
         }
       />
       <div className="w-full mt-8">

--- a/frontend/components/user/SignInForm.component.tsx
+++ b/frontend/components/user/SignInForm.component.tsx
@@ -64,14 +64,14 @@ const SignInForm = ({ onSubmit, data, setForm }: SignInProps) => {
         wrongMessage={"이메일 형식이 올바르지 않습니다."}
       />
       <InputFormItem
-        placeholder={"********"}
+        placeholder={"**********"}
         type="password"
         value={password}
         onChange={(e) => setForm({ name: "password", value: e.target.value })}
         isWrong={isWarning.password}
-        wrongMessage={"비밀번호는 8자 이상 20자 이하입니다."}
-        maxLength={20}
-        minLength={8}
+        wrongMessage={
+          "비밀번호는 10자이상, 숫자 최소 1자 이상, 특수문자 최소 1자 이상이어야 합니다."
+        }
       />
       <div className="w-full mt-8">
         <button

--- a/frontend/components/user/SignUpForm.component.tsx
+++ b/frontend/components/user/SignUpForm.component.tsx
@@ -85,16 +85,18 @@ const SignUpForm = ({ onSubmit, data, setForm }: SignUpProps) => {
       />
       <InputFormItem
         label={"비밀번호"}
-        placeholder={"********"}
+        placeholder={"**********"}
         type="password"
         value={password}
         onChange={(e) => setForm({ name: "password", value: e.target.value })}
         isWrong={isWarning.password}
-        wrongMessage={"비밀번호는 8자 이상이어야 합니다."}
+        wrongMessage={
+          "비밀번호는 10자이상, 숫자 최소 1자 이상, 특수문자 최소 1자 이상이어야 합니다."
+        }
       />
       <InputFormItem
         label={"비밀번호 확인"}
-        placeholder={"********"}
+        placeholder={"**********"}
         type="password"
         value={passwordConfirm ?? ""}
         onChange={(e) =>

--- a/frontend/components/user/SignUpForm.component.tsx
+++ b/frontend/components/user/SignUpForm.component.tsx
@@ -91,7 +91,7 @@ const SignUpForm = ({ onSubmit, data, setForm }: SignUpProps) => {
         onChange={(e) => setForm({ name: "password", value: e.target.value })}
         isWrong={isWarning.password}
         wrongMessage={
-          "비밀번호는 10자이상, 숫자 최소 1자 이상, 특수문자 최소 1자 이상이어야 합니다."
+          "비밀번호는 10자 이상이어야 하며, 최소 1개의 숫자와 1개의 특수문자를 포함해야 합니다."
         }
       />
       <InputFormItem

--- a/frontend/src/functions/validator.ts
+++ b/frontend/src/functions/validator.ts
@@ -29,7 +29,7 @@ export const isEmail = (email: string): boolean => {
 };
 
 export const isPassword = (password: string): boolean => {
-  const re = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{10,}$/;
+  const re = /^(?=.*[!@#$%^&*])(?=.*\d).{10,}$/;
   return re.test(password);
 };
 


### PR DESCRIPTION
## 관련 이슈

- closes #234 

### 작업 분류

- [x] 버그 수정
- [ ] 신규 기능 추가
- [ ] 프로젝트 구조 변경
- [ ] 코드 스타일 변경
- [x] 기존 기능 개선
- [ ] 문서 수정

## PR을 통해 해결하려는 문제가 무엇인가요? 🚀
비밀번호 유효성 검사 수정입니다.

## PR에서 핵심적으로 변경된 부분이 어떤 부분인가요? 👀
### 백엔드의 비밀번호 유효성 검사
- 특수 문자 최소 1자 이상
- 숫자 최소 1자 이상
- 전체 문자 10자 이상

백엔드의 유효성 검사와 맞게 프론트도 변경하였습니다.
비밀 번호 input에서 minLength 속성을 제거하였는데 이유는 minLength를 지키지 않았을 때 크롬 자체적으로 경고 표시가 나오는 ui가 별로라고 생각했기 때문입니다.

## 핵심 변경사항 이외 추가적으로 변경된 사항이 있나요? ➕
회원 가입 성공 시 메인 페이지로 이동하던 로직은 로그인 페이지로 이동하게 변경하였습니다.


## 체크리스트 ✅

- [x] `reviewers` 설정
- [x] `assignees` 설정
- [x] `label` 설정
