### PR TITLE
bug: 빌드 시 prettier 에러 해결

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -15,6 +15,7 @@
     "prettier"
   ],
   "rules": {
+    "useTabs": false,
     "@typescript-eslint/no-redeclare": "off",
     "@next/next/no-img-element": "off",
     "react/react-in-jsx-scope": "off",


### PR DESCRIPTION
## 관련 이슈

- closes #244

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능 추가
- [ ] 프로젝트 구조 변경
- [ ] 코드 스타일 변경
- [ ] 기존 기능 개선
- [ ] 문서 수정

## PR을 통해 해결하려는 문제가 무엇인가요? 🚀

빌드 시 발생하는 prettier 에러를 해결합니다.
<img width="1665" alt="prettier_error" src="https://github.com/user-attachments/assets/82c4ed25-1551-40b0-9cfe-1cb731260140" />

## PR에서 핵심적으로 변경된 부분이 어떤 부분인가요? 👀

eslintrc 의 rules에  "useTabs": false를 추가했습니다.
prettierrc의 "tabWidth": 2가 useTabs가 false일 때만 적용되다보니 발생한 문제라고 생각합니다.

## 체크리스트 ✅

- [x] `reviewers` 설정
- [x] `assignees` 설정
- [x] `label` 설정
