### PR TITLE
refactor: 좌측 하단 고정된 useInfo 요소와 navbar가 겹치는 부분 개선

### DIFF
--- a/frontend/components/common/navbar/Navbar.tsx
+++ b/frontend/components/common/navbar/Navbar.tsx
@@ -35,7 +35,10 @@ const CommonNavbar = () => {
         <NavbarManagePassState currentType={currentType} isShort={isShort} />
         <NavbarOperation currentType={currentType} isShort={isShort} />
       </div>
-      <NavbarUserInfo />
+
+      <div className="h-12">
+        <NavbarUserInfo />
+      </div>
     </nav>
   );
 };

--- a/frontend/components/common/navbar/UserInfo.tsx
+++ b/frontend/components/common/navbar/UserInfo.tsx
@@ -25,17 +25,19 @@ const NavbarUserInfo = () => {
   } = useQuery(["user"], () => getMyInfo());
 
   const renderContent = (content: React.ReactNode) => (
-    <div className="group flex items-center">
-      <div className="w-12 h-12 bg-white rounded-full shadow-md flex items-center justify-center overflow-hidden">
-        <Image
-          src={econoLogo}
-          alt="econo-Logo"
-          className="w-full h-full object-contain"
-        />
-      </div>
+    <div className="flex items-center">
+      <div className="relative group">
+        <div className="w-12 h-12 bg-white rounded-full shadow-md flex items-center justify-center overflow-hidden">
+          <Image
+            src={econoLogo}
+            alt="Econo 3D Logo"
+            className="w-full h-full object-contain"
+          />
+        </div>
 
-      <div className="ml-2 transition-all duration-300 ease-in-out opacity-0 transform -translate-x-2 group-hover:opacity-100 group-hover:translate-x-0">
-        {content}
+        <div className="absolute left-full top-0 ml-2 transition-all duration-300 ease-in-out opacity-0 transform -translate-x-2 group-hover:opacity-100 group-hover:translate-x-0 pointer-events-none whitespace-nowrap">
+          {content}
+        </div>
       </div>
     </div>
   );

--- a/frontend/components/common/navbar/UserInfo.tsx
+++ b/frontend/components/common/navbar/UserInfo.tsx
@@ -2,8 +2,10 @@
 
 import { getMyInfo } from "@/src/apis/interview";
 import { useQuery } from "@tanstack/react-query";
+import econoLogo from "@/public/images/econo-3d-logo.png";
 import Txt from "../Txt.component";
 import LogoutBtn from "./LogoutBtn";
+import Image from "next/image";
 
 const roleTranslater = (role: keyof typeof roleMap) => {
   const roleMap = {
@@ -22,27 +24,61 @@ const NavbarUserInfo = () => {
     isError,
   } = useQuery(["user"], () => getMyInfo());
 
+  const renderContent = (content: React.ReactNode) => (
+    <div className="group flex items-center">
+      <div className="w-12 h-12 bg-white rounded-full shadow-md flex items-center justify-center overflow-hidden">
+        <Image
+          src={econoLogo}
+          alt="econo-Logo"
+          className="w-full h-full object-contain"
+        />
+      </div>
+
+      <div className="ml-2 transition-all duration-300 ease-in-out opacity-0 transform -translate-x-2 group-hover:opacity-100 group-hover:translate-x-0">
+        {content}
+      </div>
+    </div>
+  );
+
   if (!loggedInUserInfo || isLoading) {
-    return <div className="fixed bottom-12">loading...</div>;
+    return (
+      <div className="fixed bottom-12">
+        {renderContent(
+          <div className="bg-white shadow-md rounded-lg p-2 text-sm">
+            loading...
+          </div>
+        )}
+      </div>
+    );
   }
 
   if (isError) {
-    return <div className="fixed bottom-12">error</div>;
+    return (
+      <div className="fixed bottom-12">
+        {renderContent(
+          <div className="bg-white shadow-md rounded-lg p-2 text-sm">error</div>
+        )}
+      </div>
+    );
   }
 
   const { name, role, year } = loggedInUserInfo;
 
   return (
     <div className="fixed bottom-12">
-      <div>
-        <Txt className="font-medium">{name}</Txt>
-        <LogoutBtn />
-      </div>
-      <div>
-        <Txt className="text-secondary-200">
-          {`${year}기 | ${roleTranslater(role)}`}
-        </Txt>
-      </div>
+      {renderContent(
+        <div className="bg-white shadow-md rounded-lg px-3 py-2">
+          <div className="flex items-center justify-between">
+            <Txt className="font-medium">{name}</Txt>
+            <LogoutBtn />
+          </div>
+          <div>
+            <Txt className="text-secondary-200 text-sm">
+              {`${year}기 | ${roleTranslater(role)}`}
+            </Txt>
+          </div>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## 관련 이슈


- closes #247 

### 작업 분류

<!---
  버그 수정: 버그 수정에 대한 PR일 경우
  신규 기능 추가: 논의된 새로운 기능을 추가하였을 경우
  프로젝트 구조 변경: 디렉터리 구조나 코드 계층(추상화 레벨)이 변경된 경우
  코드 스타일 변경: 린트 규칙, 코딩 컨벤션 등의 변경
  문서 수정: 이슈 템플릿, README, CONTRIBUTE.md 등 프로젝트 관련 문서가 변경될 경우
--->

- [ ] 버그 수정
- [ ] 신규 기능 추가
- [ ] 프로젝트 구조 변경
- [ ] 코드 스타일 변경
- [ ] 기존 기능 개선
- [ ] 문서 수정

## PR을 통해 해결하려는 문제가 무엇인가요? 🚀

고정된 useInfo 요소가 navbar와 겹치는 부분을 개선합니다.
<br/>
<img width="288" alt="스크린샷 2025-02-26 오후 5 20 01" src="https://github.com/user-attachments/assets/5909d188-1053-4224-9c5e-f4a1bac0780b" />

## PR에서 핵심적으로 변경된 부분이 어떤 부분인가요? 👀
![gif2](https://github.com/user-attachments/assets/c0376edf-404c-4807-b3f4-25db923a4276)
- 로고를 추가해 hover 했을 때 유저 정보가 뜨도록 변경했습니다.

## 핵심 변경사항 이외 추가적으로 변경된 사항이 있나요? ➕
- 유저정보를 감싸는 부분에 높이를 주어 로고 자체가 안겹치고 아래까지 내려가게 변경했습니다.
- 고정된 요소는 가져가되 불편함(겹침)을 최소화 하고자 로고를 넣어봤습니다.



## 이런 부분을 신경써서 봐주셨으면 좋겠어요. 🙋🏻‍♂️
- renderContent같은 요소도 따로 분리를 하는게 좋을까요?

## 체크리스트 ✅

- [ ] `reviewers` 설정
- [ ] `assignees` 설정
- [ ] `label` 설정
