### PR TITLE
fix: canApplicationNext 에서 오류 메세지가 없을 때 true 리턴하도록 수정

### DIFF
--- a/frontend/src/hooks/useApplication.tsx
+++ b/frontend/src/hooks/useApplication.tsx
@@ -117,7 +117,6 @@ export const useApplication = () => {
   ) => {
     const nonValidatedQuestion = applicationNames.filter((name) => {
       const localStorageValueFromName = localStorage.get<string>(name, "");
-
       switch (name) {
         case "personalInformationAgreeForPortfolio":
         case "personalInformationAgree":
@@ -135,7 +134,6 @@ export const useApplication = () => {
           return localStorageValueFromName.length === 0;
       }
     });
-
     const name = nonValidatedQuestion[0];
 
     if (!name) return;
@@ -193,12 +191,12 @@ export const useApplication = () => {
   const canApplicationNext = (applicationNames: Array<string>) => {
     const requiredQuestionValidateMessage =
       getRequiredQuestionValidateMessage(applicationNames);
-
     if (requiredQuestionValidateMessage) {
       alert(requiredQuestionValidateMessage);
       moveToInvalidInput(applicationNames);
       return false;
     }
+    return true;
   };
 
   const postApplication = async (


### PR DESCRIPTION
## 관련 이슈
#265 


### 작업 분류

<!---
  버그 수정: 버그 수정에 대한 PR일 경우
  신규 기능 추가: 논의된 새로운 기능을 추가하였을 경우
  프로젝트 구조 변경: 디렉터리 구조나 코드 계층(추상화 레벨)이 변경된 경우
  코드 스타일 변경: 린트 규칙, 코딩 컨벤션 등의 변경
  문서 수정: 이슈 템플릿, README, CONTRIBUTE.md 등 프로젝트 관련 문서가 변경될 경우
--->

- [x] 버그 수정
- [ ] 신규 기능 추가
- [ ] 프로젝트 구조 변경
- [ ] 코드 스타일 변경
- [ ] 기존 기능 개선
- [ ] 문서 수정

## PR을 통해 해결하려는 문제가 무엇인가요? 🚀
필수 질문을 모두 입력해도 제출이 되지 않음.
<!---
  이 PR은 어떤 문제를 해결하는지, 리뷰어가 알 수 있게 기술해주세요.
--->

## PR에서 핵심적으로 변경된 부분이 어떤 부분인가요? 👀
제출이 되도록 수정
<!---
  해결하려는 문제에 연관된 핵심 변경사항을 기술해주세요.
--->

## 핵심 변경사항 이외 추가적으로 변경된 사항이 있나요? ➕

<!---
  핵심 변경사항 이외 변경한 내용을 기술해주세요.
--->

## 추가적으로, 리뷰어가 리뷰하며 알아야 할 정보가 있나요? 🙌

canApplicationNext 에서 메세지가 없을 때 true 를 리턴하도록 했습니다.
getRequiredQuestionValidateMessage 에서 오류 메세지가 없다면 undefined 를 return 해도 될 지, 아니면 다른 특정 값을 넣는게 좋을지 의견 있으시면 말씀해주시면 감사하겠습니다!
<!---
  참고링크, 리뷰 시 궁금한 점, 주의할 점 등등..
  리뷰어가 리뷰 전에 알아야 할 정보를 기술해주세요.
--->

## 이런 부분을 신경써서 봐주셨으면 좋겠어요. 🙋🏻‍♂️

<!---
  문제를 해결하며 궁금했던 점, 리뷰어와 같이 이야기 나눠보고 싶은 점
--->

## 체크리스트 ✅

- [X] `reviewers` 설정
- [X] `assignees` 설정
- [X] `label` 설정
