### PR TITLE
refactor: 합/불 라벨링 사용자 피드백 추가 & 공통 로직 설정

### DIFF
--- a/frontend/components/applicant/Board.tsx
+++ b/frontend/components/applicant/Board.tsx
@@ -9,6 +9,8 @@ import ApplicantDetailLeft from "./_applicant/ApplicantDetailLeft";
 import BoardTable from "../common/board/BoardTable";
 import useModalState from "../../src/hooks/useModalState";
 import BoardModal from "../common/board/BoardModal";
+import { useRouter } from "next/navigation";
+import { CURRENT_GENERATION } from "@/src/constants";
 
 interface ApplicantBoardProps {
   generation: string;
@@ -19,6 +21,8 @@ const ApplicantBoard = ({ generation, applicants }: ApplicantBoardProps) => {
   const [selectedApplicant, setSelectedApplicant] = useState<ApplicantReq[]>(
     []
   );
+
+  const navigate = useRouter();
 
   const { isOpen, openModal, closeModal } = useModalState();
 
@@ -50,6 +54,7 @@ const ApplicantBoard = ({ generation, applicants }: ApplicantBoardProps) => {
   }));
 
   const handleModalOpen = (id: string) => () => {
+    navigate.replace(`/applicant/${CURRENT_GENERATION}?applicantId=${id}`);
     openModal();
     setSelectedApplicant(
       applicants.filter((value) => applicantDataFinder(value, "id") === id)[0]

--- a/frontend/components/applicant/Board.tsx
+++ b/frontend/components/applicant/Board.tsx
@@ -9,8 +9,6 @@ import ApplicantDetailLeft from "./_applicant/ApplicantDetailLeft";
 import BoardTable from "../common/board/BoardTable";
 import useModalState from "../../src/hooks/useModalState";
 import BoardModal from "../common/board/BoardModal";
-import { useRouter } from "next/navigation";
-import { CURRENT_GENERATION } from "@/src/constants";
 
 interface ApplicantBoardProps {
   generation: string;
@@ -21,8 +19,6 @@ const ApplicantBoard = ({ generation, applicants }: ApplicantBoardProps) => {
   const [selectedApplicant, setSelectedApplicant] = useState<ApplicantReq[]>(
     []
   );
-
-  const navigate = useRouter();
 
   const { isOpen, openModal, closeModal } = useModalState();
 
@@ -54,7 +50,6 @@ const ApplicantBoard = ({ generation, applicants }: ApplicantBoardProps) => {
   }));
 
   const handleModalOpen = (id: string) => () => {
-    navigate.replace(`/applicant/${CURRENT_GENERATION}?applicantId=${id}`);
     openModal();
     setSelectedApplicant(
       applicants.filter((value) => applicantDataFinder(value, "id") === id)[0]

--- a/frontend/components/applicant/_applicant/ApplicantDetailLeft.tsx
+++ b/frontend/components/applicant/_applicant/ApplicantDetailLeft.tsx
@@ -22,10 +22,8 @@ const ApplicantDetailLeft = ({ data, cardId, generation }: DetailLeftProps) => {
   const applicantId = searchParams.get("applicantId");
   const postId = applicantDataFinder(data, "id");
 
-  const { mutate: updateApplicantPassState } = useOptimisticApplicantPassUpdate(
-    generation,
-    postId
-  );
+  const { mutate: updateApplicantPassState } =
+    useOptimisticApplicantPassUpdate(generation);
   const { data: userData } = useQuery(["user"], getMyInfo);
 
   const { applicant, isLoading, isError } = useApplicantById(applicantId);

--- a/frontend/components/applicant/_applicant/ApplicantDetailLeft.tsx
+++ b/frontend/components/applicant/_applicant/ApplicantDetailLeft.tsx
@@ -11,6 +11,7 @@ import ApplicantComment from "../applicantNode/comment/Comment.component";
 import { useApplicantById } from "@/src/hooks/applicant/useApplicantById";
 
 import { useOptimisticApplicantPassUpdate } from "@/src/hooks/applicant/useOptimisticApplicantPassUpdate";
+import { getPassState } from "@/src/functions/passState";
 
 interface DetailLeftProps {
   data: ApplicantReq[];
@@ -47,6 +48,10 @@ const ApplicantDetailLeft = ({ data, cardId, generation }: DetailLeftProps) => {
     });
   };
 
+  if (!applicant) {
+    return <div>로딩중...</div>;
+  }
+
   return (
     <>
       <CustomResource
@@ -57,11 +62,7 @@ const ApplicantDetailLeft = ({ data, cardId, generation }: DetailLeftProps) => {
         }
         onClickPass={onClickPass}
         onClickNonPass={onClickNonPass}
-        passState={
-          applicant && !Array.isArray(applicant)
-            ? applicant.state.passState
-            : "non-processed"
-        }
+        passState={getPassState(applicant)}
       />
       <ApplicantLabel postId={postId} generation={generation} />
       <ApplicantComment

--- a/frontend/components/applicant/_applicant/ApplicantDetailLeft.tsx
+++ b/frontend/components/applicant/_applicant/ApplicantDetailLeft.tsx
@@ -11,6 +11,8 @@ import { applicantDataFinder } from "@/src/functions/finder";
 import { getMyInfo } from "@/src/apis/interview";
 import ApplicantLabel from "../applicantNode/Label.component";
 import ApplicantComment from "../applicantNode/comment/Comment.component";
+import { useApplicantById } from "@/src/hooks/applicant/useApplicantById";
+import { useSearchParams } from "next/navigation";
 
 interface DetailLeftProps {
   data: ApplicantReq[];
@@ -18,22 +20,52 @@ interface DetailLeftProps {
   cardId: number;
 }
 const ApplicantDetailLeft = ({ data, cardId, generation }: DetailLeftProps) => {
+  const searchParams = useSearchParams();
+  const applicantId = searchParams.get("applicantId");
+
   const queryClient = useQueryClient();
   const { mutate: updateApplicantPassState } = useMutation({
     mutationFn: (params: PatchApplicantPassStateParams) =>
       patchApplicantPassState(params),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: [
-          "allApplicantsWithPassState",
-          applicantDataFinder(data, "generation"),
-        ],
-      });
+    onMutate: async (newData) => {
+      await queryClient.cancelQueries([
+        "allApplicantsWithPassState",
+        generation,
+      ]);
+      const previousData = queryClient.getQueryData([
+        "allApplicantsWithPassState",
+        generation,
+      ]);
+
+      queryClient.setQueryData(
+        ["allApplicantsWithPassState", generation],
+        (oldData: any) => {
+          if (!oldData) return oldData;
+          return oldData.map((applicant: any) =>
+            applicant.id === postId
+              ? { ...applicant, passState: newData.afterState }
+              : applicant
+          );
+        }
+      );
+
+      return { previousData };
+    },
+    onError: (err, newData, context) => {
+      queryClient.setQueryData(
+        ["allApplicantsWithPassState", generation],
+        context?.previousData
+      );
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries(["allApplicantsWithPassState", generation]);
     },
   });
   const { data: userData } = useQuery(["user"], getMyInfo);
 
   const postId = applicantDataFinder(data, "id");
+
+  const { applicant, isLoading, isError } = useApplicantById(applicantId);
 
   const onClickPass = () => {
     const ok = confirm("합격 처리하시겠습니까?");
@@ -63,6 +95,11 @@ const ApplicantDetailLeft = ({ data, cardId, generation }: DetailLeftProps) => {
         }
         onClickPass={onClickPass}
         onClickNonPass={onClickNonPass}
+        passState={
+          applicant && !Array.isArray(applicant)
+            ? applicant.state.passState
+            : "non-processed"
+        }
       />
       <ApplicantLabel postId={postId} generation={generation} />
       <ApplicantComment

--- a/frontend/components/applicant/_applicant/ApplicantDetailLeft.tsx
+++ b/frontend/components/applicant/_applicant/ApplicantDetailLeft.tsx
@@ -26,7 +26,10 @@ const ApplicantDetailLeft = ({ data, cardId, generation }: DetailLeftProps) => {
     useOptimisticApplicantPassUpdate(generation);
   const { data: userData } = useQuery(["user"], getMyInfo);
 
-  const { applicant, isLoading, isError } = useApplicantById(applicantId);
+  const { applicant, isLoading, isError } = useApplicantById({
+    applicantId,
+    generation,
+  });
 
   const onClickPass = () => {
     const ok = confirm("합격 처리하시겠습니까?");

--- a/frontend/components/applicant/_applicant/ApplicantDetailLeft.tsx
+++ b/frontend/components/applicant/_applicant/ApplicantDetailLeft.tsx
@@ -9,7 +9,7 @@ import { getMyInfo } from "@/src/apis/interview";
 import ApplicantLabel from "../applicantNode/Label.component";
 import ApplicantComment from "../applicantNode/comment/Comment.component";
 import { useApplicantById } from "@/src/hooks/applicant/useApplicantById";
-import { useSearchParams } from "next/navigation";
+
 import { useOptimisticApplicantPassUpdate } from "@/src/hooks/applicant/useOptimisticApplicantPassUpdate";
 
 interface DetailLeftProps {
@@ -18,8 +18,6 @@ interface DetailLeftProps {
   cardId: number;
 }
 const ApplicantDetailLeft = ({ data, cardId, generation }: DetailLeftProps) => {
-  const searchParams = useSearchParams();
-  const applicantId = searchParams.get("applicantId");
   const postId = applicantDataFinder(data, "id");
 
   const { mutate: updateApplicantPassState } =
@@ -27,7 +25,7 @@ const ApplicantDetailLeft = ({ data, cardId, generation }: DetailLeftProps) => {
   const { data: userData } = useQuery(["user"], getMyInfo);
 
   const { applicant, isLoading, isError } = useApplicantById({
-    applicantId,
+    applicantId: postId,
     generation,
   });
 

--- a/frontend/components/applicant/_applicant/_applicantNode/CustomResource.tsx
+++ b/frontend/components/applicant/_applicant/_applicantNode/CustomResource.tsx
@@ -3,12 +3,14 @@ import Portfolio from "../../applicantNode/Portfolio";
 import { ApplicantReq } from "@/src/apis/applicant";
 import Txt from "@/components/common/Txt.component";
 import { getApplicantPassState } from "@/src/functions/formatter";
+import { ApplicantPassState } from "@/src/apis/kanban";
 
 interface CustomResourceProps {
   data: ApplicantReq[];
   ableToEdit?: boolean;
   onClickPass?: () => void;
   onClickNonPass?: () => void;
+  passState: ApplicantPassState;
 }
 
 const CustomResource = ({
@@ -16,6 +18,7 @@ const CustomResource = ({
   ableToEdit = false,
   onClickPass,
   onClickNonPass,
+  passState,
 }: CustomResourceProps) => {
   return (
     <>
@@ -30,8 +33,7 @@ const CustomResource = ({
           )}] ${applicantDataFinder(data, "name")}`}</Txt>
           <div className="flex justify-between grow items-center">
             <Txt typography="h5" color="light_gray" className="truncate">
-              {getApplicantPassState(applicantDataFinder(data, "passState")) ||
-                "에러 발생"}
+              {getApplicantPassState(passState)}
             </Txt>
             {ableToEdit && (
               <div className="flex gap-4">

--- a/frontend/components/applicant/_applicant/_applicantNode/CustomResource.tsx
+++ b/frontend/components/applicant/_applicant/_applicantNode/CustomResource.tsx
@@ -4,6 +4,7 @@ import { ApplicantReq } from "@/src/apis/applicant";
 import Txt from "@/components/common/Txt.component";
 import { getApplicantPassState } from "@/src/functions/formatter";
 import { ApplicantPassState } from "@/src/apis/kanban";
+import CardApplicantStatusLabel from "@/components/common/CardApplicantStatusLabel";
 
 interface CustomResourceProps {
   data: ApplicantReq[];
@@ -32,9 +33,7 @@ const CustomResource = ({
             "field"
           )}] ${applicantDataFinder(data, "name")}`}</Txt>
           <div className="flex justify-between grow items-center">
-            <Txt typography="h5" color="light_gray" className="truncate">
-              {getApplicantPassState(passState)}
-            </Txt>
+            <CardApplicantStatusLabel passState={passState} />
             {ableToEdit && (
               <div className="flex gap-4">
                 <button

--- a/frontend/components/applicant/applicantNode/CustomResource.component.tsx
+++ b/frontend/components/applicant/applicantNode/CustomResource.component.tsx
@@ -4,7 +4,7 @@ import { applicantDataFinder } from "@/src/functions/finder";
 import Portfolio from "./Portfolio";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSearchParams } from "next/navigation";
-import KanbanCardApplicantStatusLabel from "@/components/kanban/card/CardApplicantStatusLabel";
+import CardApplicantStatusLabel from "@/components/common/CardApplicantStatusLabel";
 import { useAtomValue } from "jotai";
 import { KanbanSelectedButtonNumberState } from "@/src/stores/kanban/Navbar.atoms";
 import { getMyInfo } from "@/src/apis/interview";
@@ -102,7 +102,7 @@ const ApplicantResource = ({
             <Txt className="text-xl text-secondary-200 font-medium">
               {applicantDataFinder(data, "major")}
             </Txt>
-            <KanbanCardApplicantStatusLabel passState={initialState} />
+            <CardApplicantStatusLabel passState={initialState} />
           </div>
           <Txt typography="h2">{`[${applicantDataFinder(
             data,

--- a/frontend/components/applicant/applicantNode/CustomResource.component.tsx
+++ b/frontend/components/applicant/applicantNode/CustomResource.component.tsx
@@ -10,6 +10,7 @@ import { getMyInfo } from "@/src/apis/interview";
 
 import { useOptimisticApplicantPassUpdate } from "@/src/hooks/applicant/useOptimisticApplicantPassUpdate";
 import { useApplicantById } from "@/src/hooks/applicant/useApplicantById";
+import { getPassState } from "@/src/functions/passState";
 
 interface ApplicantResourceProps {
   data: ApplicantReq[];
@@ -76,13 +77,7 @@ const ApplicantResource = ({
             <Txt className="text-xl text-secondary-200 font-medium">
               {applicantDataFinder(data, "major")}
             </Txt>
-            <CardApplicantStatusLabel
-              passState={
-                initialState && !Array.isArray(initialState)
-                  ? initialState.state.passState
-                  : "non-processed"
-              }
-            />
+            <CardApplicantStatusLabel passState={getPassState(initialState)} />
           </div>
           <Txt typography="h2">{`[${applicantDataFinder(
             data,

--- a/frontend/components/applicant/applicantNode/CustomResource.component.tsx
+++ b/frontend/components/applicant/applicantNode/CustomResource.component.tsx
@@ -1,5 +1,5 @@
 import Txt from "@/components/common/Txt.component";
-import { ApplicantReq, patchApplicantState } from "@/src/apis/applicant";
+import { ApplicantReq } from "@/src/apis/applicant";
 import { applicantDataFinder } from "@/src/functions/finder";
 import Portfolio from "./Portfolio";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -10,6 +10,10 @@ import { KanbanSelectedButtonNumberState } from "@/src/stores/kanban/Navbar.atom
 import { getMyInfo } from "@/src/apis/interview";
 import { findApplicantState } from "@/src/utils/applicant";
 import { ApplicantPassState, getKanbanCards } from "@/src/apis/kanban";
+import {
+  patchApplicantPassState,
+  PatchApplicantPassStateParams,
+} from "@/src/apis/passState";
 
 interface ApplicantResourceProps {
   data: ApplicantReq[];
@@ -49,9 +53,9 @@ const ApplicantResource = ({
     queryKey: ["user"],
     queryFn: getMyInfo,
   });
-  const { mutate } = useMutation({
-    mutationFn: (afterState: "non-pass" | "pass") =>
-      patchApplicantState(`${applicantId}`, afterState),
+  const { mutate: updateApplicantPassState } = useMutation({
+    mutationFn: (params: PatchApplicantPassStateParams) =>
+      patchApplicantPassState(params),
     onMutate: async () => {
       await queryClient.cancelQueries([
         "applicantState",
@@ -78,12 +82,22 @@ const ApplicantResource = ({
     },
   });
 
-  const onFailedButtonClick = () => {
-    mutate("non-pass");
+  const onClickPass = () => {
+    const ok = confirm("합격 처리하시겠습니까?");
+    if (!ok) return;
+    updateApplicantPassState({
+      applicantId: postId,
+      afterState: "pass",
+    });
   };
 
-  const onPassedButtonClick = () => {
-    mutate("pass");
+  const onClickNonPass = () => {
+    const ok = confirm("불합격 처리하시겠습니까?");
+    if (!ok) return;
+    updateApplicantPassState({
+      applicantId: postId,
+      afterState: "non-pass",
+    });
   };
 
   if (!initialState || isLoading || !myInfo || myInfoLoading) {
@@ -113,16 +127,16 @@ const ApplicantResource = ({
           myInfo.role === "ROLE_PRESIDENT") && (
           <div className="flex gap-5">
             <button
-              onClick={onFailedButtonClick}
-              className="bg-zinc-200 w-20 h-20 hover:bg-sky-400 rounded-xl"
-            >
-              불합격
-            </button>
-            <button
-              onClick={onPassedButtonClick}
+              onClick={onClickPass}
               className="bg-zinc-200 w-20 h-20 hover:bg-sky-400 rounded-xl"
             >
               합격
+            </button>
+            <button
+              onClick={onClickNonPass}
+              className="bg-zinc-200 w-20 h-20 hover:bg-sky-400 rounded-xl"
+            >
+              불합격
             </button>
           </div>
         )}

--- a/frontend/components/applicant/applicantNode/CustomResource.component.tsx
+++ b/frontend/components/applicant/applicantNode/CustomResource.component.tsx
@@ -24,7 +24,7 @@ const ApplicantResource = ({
   generation,
 }: ApplicantResourceProps) => {
   const searchParams = useSearchParams();
-  const applicantId = searchParams.get("applicantId");
+  const applicantId = searchParams.get("applicantId") ?? "";
 
   const {
     applicant: initialState,

--- a/frontend/components/applicant/applicantNode/CustomResource.component.tsx
+++ b/frontend/components/applicant/applicantNode/CustomResource.component.tsx
@@ -55,10 +55,8 @@ const ApplicantResource = ({
     queryKey: ["user"],
     queryFn: getMyInfo,
   });
-  const { mutate: updateApplicantPassState } = useOptimisticApplicantPassUpdate(
-    generation,
-    postId
-  );
+  const { mutate: updateApplicantPassState } =
+    useOptimisticApplicantPassUpdate(generation);
 
   const onClickPass = () => {
     const ok = confirm("합격 처리하시겠습니까?");

--- a/frontend/components/common/CardApplicantStatusLabel.tsx
+++ b/frontend/components/common/CardApplicantStatusLabel.tsx
@@ -25,9 +25,7 @@ export const labelConfig: Record<ApplicantPassState, labelConfigType> = {
   },
 };
 
-const KanbanCardApplicantStatusLabel = ({
-  passState,
-}: KanbanCardReq["state"]) => {
+const CardApplicantStatusLabel = ({ passState }: KanbanCardReq["state"]) => {
   const { backgroundColor, label } = labelConfig[passState];
   return (
     <div className={cn("text-xs px-2.5 py-1 rounded-lg", backgroundColor)}>
@@ -36,4 +34,4 @@ const KanbanCardApplicantStatusLabel = ({
   );
 };
 
-export default KanbanCardApplicantStatusLabel;
+export default CardApplicantStatusLabel;

--- a/frontend/components/kanban/card/Card.component.tsx
+++ b/frontend/components/kanban/card/Card.component.tsx
@@ -2,7 +2,7 @@ import { KanbanCardData } from "@/src/stores/kanban/Kanban.atoms";
 import { cn } from "@/src/utils/cn";
 import { useParams, useRouter } from "next/navigation";
 import Icon from "@/components/common/Icon";
-import KanbanCardApplicantStatusLabel from "./CardApplicantStatusLabel";
+import CardApplicantStatusLabel from "../../common/CardApplicantStatusLabel";
 
 type KanbanCardComponentType = {
   data: KanbanCardData | null;
@@ -57,7 +57,7 @@ function KanbanCardComponent({
     >
       <div className="text-xs text-secondary-200 flex justify-between items-center">
         {major}
-        <KanbanCardApplicantStatusLabel passState={passState} />
+        <CardApplicantStatusLabel passState={passState} />
       </div>
       <div className="font-bold truncate">{title}</div>
       <div className="mt-2 flex justify-between items-center text-sm text-secondary-200">

--- a/frontend/components/kanban/card/Card.component.tsx
+++ b/frontend/components/kanban/card/Card.component.tsx
@@ -2,7 +2,7 @@ import { KanbanCardData } from "@/src/stores/kanban/Kanban.atoms";
 import { cn } from "@/src/utils/cn";
 import { useParams, useRouter } from "next/navigation";
 import Icon from "@/components/common/Icon";
-import CardApplicantStatusLabel from "../../common/CardApplicantStatusLabel";
+import CardApplicantStatusLabel from "@/components/common/CardApplicantStatusLabel";
 
 type KanbanCardComponentType = {
   data: KanbanCardData | null;

--- a/frontend/components/passState/ApplicantsList.tsx
+++ b/frontend/components/passState/ApplicantsList.tsx
@@ -1,18 +1,16 @@
 "use client";
 
-import {
-  getAllApplicantsWithPassState,
-  patchApplicantPassState,
-} from "@/src/apis/passState";
+import { getAllApplicantsWithPassState } from "@/src/apis/passState";
 import { CURRENT_GENERATION } from "@/src/constants";
 import { usePathname } from "next/navigation";
 import Txt from "../common/Txt.component";
 import { getApplicantPassState } from "@/src/functions/formatter";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import type {
   PatchApplicantPassStateParams,
   Answer,
 } from "@/src/apis/passState";
+import { useOptimisticApplicantPassUpdate } from "@/src/hooks/applicant/useOptimisticApplicantPassUpdate";
 
 function sortApplicantsByField1(applicants: Answer[]) {
   const passStateOrder = {
@@ -46,7 +44,6 @@ interface ApplicantsListProps {
 }
 const ApplicantsList = ({ sortedBy }: ApplicantsListProps) => {
   const selectedGeneration = usePathname().split("/")[2];
-  const queryClient = useQueryClient();
 
   const {
     data: allApplicants,
@@ -56,15 +53,8 @@ const ApplicantsList = ({ sortedBy }: ApplicantsListProps) => {
     getAllApplicantsWithPassState(selectedGeneration)
   );
 
-  const { mutate: updateApplicantPassState } = useMutation({
-    mutationFn: (params: PatchApplicantPassStateParams) =>
-      patchApplicantPassState(params),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["allApplicantsWithPassState", selectedGeneration],
-      });
-    },
-  });
+  const { mutate: updateApplicantPassState, isLoading: mutationLoading } =
+    useOptimisticApplicantPassUpdate(selectedGeneration);
 
   {
     if (+selectedGeneration !== CURRENT_GENERATION) {
@@ -121,8 +111,8 @@ const ApplicantsList = ({ sortedBy }: ApplicantsListProps) => {
                 passState === "non-passed"
                   ? "red"
                   : passState === "final-passed"
-                  ? "blue"
-                  : "black"
+                    ? "blue"
+                    : "black"
               }
             >
               {getApplicantPassState(passState)}

--- a/frontend/components/passState/ApplicantsList.tsx
+++ b/frontend/components/passState/ApplicantsList.tsx
@@ -53,8 +53,10 @@ const ApplicantsList = ({ sortedBy }: ApplicantsListProps) => {
     getAllApplicantsWithPassState(selectedGeneration)
   );
 
-  const { mutate: updateApplicantPassState, isLoading: mutationLoading } =
-    useOptimisticApplicantPassUpdate(selectedGeneration);
+  const {
+    mutate: updateApplicantPassState,
+    // isLoading: isUpdatingApplicantPassState,
+  } = useOptimisticApplicantPassUpdate(selectedGeneration);
 
   {
     if (+selectedGeneration !== CURRENT_GENERATION) {

--- a/frontend/src/functions/passState.ts
+++ b/frontend/src/functions/passState.ts
@@ -1,0 +1,11 @@
+import { ApplicantPassState } from "../apis/kanban";
+import { ApplicantPartialRes } from "../hooks/applicant/useOptimisticApplicantPassUpdate";
+
+export const getPassState = (
+  applicant: ApplicantPartialRes | ApplicantPartialRes[] | null
+): ApplicantPassState => {
+  if (applicant && !Array.isArray(applicant)) {
+    return applicant.state.passState;
+  }
+  return "non-processed";
+};

--- a/frontend/src/hooks/applicant/useApplicantById.tsx
+++ b/frontend/src/hooks/applicant/useApplicantById.tsx
@@ -1,0 +1,22 @@
+import { getAllApplicantsWithPassState } from "@/src/apis/passState";
+import { useQuery } from "@tanstack/react-query";
+
+import { usePathname } from "next/navigation";
+
+export function useApplicantById(userId?: string | null) {
+  const pathname = usePathname();
+  const segments = pathname.split("/").filter((segment) => segment.length > 0);
+  const generation = segments[segments.length - 1];
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["allApplicantsWithPassState", generation],
+    queryFn: () => getAllApplicantsWithPassState(generation),
+    staleTime: 3000,
+  });
+
+  const applicant = userId
+    ? data?.find((item) => item.id === userId) || null
+    : data || [];
+
+  return { applicant, isLoading, isError };
+}

--- a/frontend/src/hooks/applicant/useApplicantById.tsx
+++ b/frontend/src/hooks/applicant/useApplicantById.tsx
@@ -1,13 +1,15 @@
 import { getAllApplicantsWithPassState } from "@/src/apis/passState";
 import { useQuery } from "@tanstack/react-query";
 
-import { usePathname } from "next/navigation";
+interface ApplicantByIdParams {
+  applicantId?: string | null;
+  generation: string;
+}
 
-export function useApplicantById(applicantId?: string | null) {
-  const pathname = usePathname();
-  const segments = pathname.split("/").filter((segment) => segment.length > 0);
-  const generation = segments[segments.length - 1];
-
+export function useApplicantById({
+  applicantId,
+  generation,
+}: ApplicantByIdParams) {
   const { data, isLoading, isError } = useQuery({
     queryKey: ["allApplicantsWithPassState", generation],
     queryFn: () => getAllApplicantsWithPassState(generation),

--- a/frontend/src/hooks/applicant/useApplicantById.tsx
+++ b/frontend/src/hooks/applicant/useApplicantById.tsx
@@ -13,12 +13,12 @@ export function useApplicantById({
   const { data, isLoading, isError } = useQuery({
     queryKey: ["allApplicantsWithPassState", generation],
     queryFn: () => getAllApplicantsWithPassState(generation),
-    staleTime: 3000,
   });
 
-  const applicant = applicantId
-    ? data?.find((item) => item.id === applicantId) || null
-    : data || [];
+  const applicant =
+    data && applicantId
+      ? data.find((item) => item.id === applicantId)
+      : data || [];
 
   return { applicant, isLoading, isError };
 }

--- a/frontend/src/hooks/applicant/useApplicantById.tsx
+++ b/frontend/src/hooks/applicant/useApplicantById.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import { usePathname } from "next/navigation";
 
-export function useApplicantById(userId?: string | null) {
+export function useApplicantById(applicantId?: string | null) {
   const pathname = usePathname();
   const segments = pathname.split("/").filter((segment) => segment.length > 0);
   const generation = segments[segments.length - 1];
@@ -14,8 +14,8 @@ export function useApplicantById(userId?: string | null) {
     staleTime: 3000,
   });
 
-  const applicant = userId
-    ? data?.find((item) => item.id === userId) || null
+  const applicant = applicantId
+    ? data?.find((item) => item.id === applicantId) || null
     : data || [];
 
   return { applicant, isLoading, isError };

--- a/frontend/src/hooks/applicant/useApplicantById.tsx
+++ b/frontend/src/hooks/applicant/useApplicantById.tsx
@@ -2,7 +2,7 @@ import { getAllApplicantsWithPassState } from "@/src/apis/passState";
 import { useQuery } from "@tanstack/react-query";
 
 interface ApplicantByIdParams {
-  applicantId?: string | null;
+  applicantId: string;
   generation: string;
 }
 

--- a/frontend/src/hooks/applicant/useOptimisticApplicantPassUpdate.tsx
+++ b/frontend/src/hooks/applicant/useOptimisticApplicantPassUpdate.tsx
@@ -1,0 +1,50 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  patchApplicantPassState,
+  PatchApplicantPassStateParams,
+} from "@/src/apis/passState";
+
+export const useOptimisticApplicantPassUpdate = (
+  generation: string,
+  postId: string
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (params: PatchApplicantPassStateParams) =>
+      patchApplicantPassState(params),
+    onMutate: async (newData) => {
+      await queryClient.cancelQueries([
+        "allApplicantsWithPassState",
+        generation,
+      ]);
+
+      const previousData = queryClient.getQueryData([
+        "allApplicantsWithPassState",
+        generation,
+      ]);
+
+      queryClient.setQueryData(
+        ["allApplicantsWithPassState", generation],
+        (oldData: any) => {
+          if (!oldData) return oldData;
+          return oldData.map((applicant: any) =>
+            applicant.id === postId
+              ? { ...applicant, passState: newData.afterState }
+              : applicant
+          );
+        }
+      );
+      return { previousData };
+    },
+    onError: (err, newData, context: any) => {
+      queryClient.setQueryData(
+        ["allApplicantsWithPassState", generation],
+        context?.previousData
+      );
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries(["allApplicantsWithPassState", generation]);
+    },
+  });
+};

--- a/frontend/src/hooks/applicant/useOptimisticApplicantPassUpdate.tsx
+++ b/frontend/src/hooks/applicant/useOptimisticApplicantPassUpdate.tsx
@@ -18,16 +18,13 @@ export interface IAnswer {
   };
 }
 
-export const useOptimisticApplicantPassUpdate = (
-  generation: string,
-  postId: string
-) => {
+export const useOptimisticApplicantPassUpdate = (generation: string) => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (params: PatchApplicantPassStateParams) =>
       patchApplicantPassState(params),
-    onMutate: async (variables) => {
+    onMutate: async (params) => {
       await queryClient.cancelQueries([
         "allApplicantsWithPassState",
         generation,
@@ -43,8 +40,8 @@ export const useOptimisticApplicantPassUpdate = (
         (oldData: IAnswer[] | undefined) => {
           if (!oldData) return oldData;
           return oldData.map((applicant: IAnswer) =>
-            applicant.id === postId
-              ? { ...applicant, passState: variables.afterState }
+            applicant.id === params.applicantId
+              ? { ...applicant, passState: params.afterState }
               : applicant
           );
         }

--- a/frontend/src/hooks/applicant/useOptimisticApplicantPassUpdate.tsx
+++ b/frontend/src/hooks/applicant/useOptimisticApplicantPassUpdate.tsx
@@ -5,7 +5,7 @@ import {
 } from "@/src/apis/passState";
 import { ApplicantPassState } from "@/src/apis/kanban";
 
-interface Answer {
+export interface ApplicantPartialRes {
   field: "개발자" | "디자이너" | "기획자";
   field1: "APP" | "WEB" | "AI" | "GAME";
   field2: "APP" | "WEB" | "AI" | "GAME" | "선택 없음";
@@ -35,9 +35,9 @@ export const useOptimisticApplicantPassUpdate = (generation: string) => {
 
       queryClient.setQueryData(
         ["allApplicantsWithPassState", generation],
-        (oldData: Answer[] | undefined) => {
+        (oldData: ApplicantPartialRes[] | undefined) => {
           if (!oldData) return oldData;
-          return oldData.map((applicant: Answer) =>
+          return oldData.map((applicant: ApplicantPartialRes) =>
             applicant.id === params.applicantId
               ? { ...applicant, passState: params.afterState }
               : applicant

--- a/frontend/src/hooks/applicant/useOptimisticApplicantPassUpdate.tsx
+++ b/frontend/src/hooks/applicant/useOptimisticApplicantPassUpdate.tsx
@@ -36,7 +36,6 @@ export const useOptimisticApplicantPassUpdate = (generation: string) => {
       queryClient.setQueryData(
         ["allApplicantsWithPassState", generation],
         (oldData: Answer[] | undefined) => {
-          console.log(oldData);
           if (!oldData) return oldData;
           return oldData.map((applicant: Answer) =>
             applicant.id === params.applicantId

--- a/frontend/src/hooks/applicant/useOptimisticApplicantPassUpdate.tsx
+++ b/frontend/src/hooks/applicant/useOptimisticApplicantPassUpdate.tsx
@@ -3,6 +3,20 @@ import {
   patchApplicantPassState,
   PatchApplicantPassStateParams,
 } from "@/src/apis/passState";
+import { ApplicantPassState } from "@/src/apis/kanban";
+
+export interface IAnswer {
+  field: "개발자" | "디자이너" | "기획자";
+  field1: "APP" | "WEB" | "AI" | "GAME";
+  field2: "APP" | "WEB" | "AI" | "GAME" | "선택 없음";
+  name: string;
+  id: string;
+  year: number;
+  state: {
+    passState: ApplicantPassState;
+    passStateToEnum: string;
+  };
+}
 
 export const useOptimisticApplicantPassUpdate = (
   generation: string,
@@ -13,7 +27,7 @@ export const useOptimisticApplicantPassUpdate = (
   return useMutation({
     mutationFn: (params: PatchApplicantPassStateParams) =>
       patchApplicantPassState(params),
-    onMutate: async (newData) => {
+    onMutate: async (variables) => {
       await queryClient.cancelQueries([
         "allApplicantsWithPassState",
         generation,
@@ -26,18 +40,18 @@ export const useOptimisticApplicantPassUpdate = (
 
       queryClient.setQueryData(
         ["allApplicantsWithPassState", generation],
-        (oldData: any) => {
+        (oldData: IAnswer[] | undefined) => {
           if (!oldData) return oldData;
-          return oldData.map((applicant: any) =>
+          return oldData.map((applicant: IAnswer) =>
             applicant.id === postId
-              ? { ...applicant, passState: newData.afterState }
+              ? { ...applicant, passState: variables.afterState }
               : applicant
           );
         }
       );
       return { previousData };
     },
-    onError: (err, newData, context: any) => {
+    onError: (err, variables, context) => {
       queryClient.setQueryData(
         ["allApplicantsWithPassState", generation],
         context?.previousData

--- a/frontend/src/hooks/applicant/useOptimisticApplicantPassUpdate.tsx
+++ b/frontend/src/hooks/applicant/useOptimisticApplicantPassUpdate.tsx
@@ -14,11 +14,6 @@ interface Answer {
   year: number;
   state: {
     passState: ApplicantPassState;
-    passStateToEnum:
-      | "non-processed"
-      | "non-passed"
-      | "first-passed"
-      | "final-passed";
   };
 }
 

--- a/frontend/src/hooks/useModalState.ts
+++ b/frontend/src/hooks/useModalState.ts
@@ -1,12 +1,23 @@
+import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";
 
 const useModalState = (initState = false) => {
   const [isOpen, setIsOpen] = useState(initState);
 
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const openModal = () => setIsOpen(true);
+
+  const closeModal = () => {
+    setIsOpen(false);
+    router.push(pathname);
+  };
+
   return {
     isOpen,
-    openModal: () => setIsOpen(true),
-    closeModal: () => setIsOpen(false),
+    openModal,
+    closeModal,
   };
 };
 

--- a/frontend/src/hooks/useModalState.ts
+++ b/frontend/src/hooks/useModalState.ts
@@ -1,18 +1,11 @@
-import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";
 
 const useModalState = (initState = false) => {
   const [isOpen, setIsOpen] = useState(initState);
 
-  const router = useRouter();
-  const pathname = usePathname();
-
   const openModal = () => setIsOpen(true);
 
-  const closeModal = () => {
-    setIsOpen(false);
-    router.push(pathname);
-  };
+  const closeModal = () => setIsOpen(false);
 
   return {
     isOpen,


### PR DESCRIPTION
## 관련 이슈

<!---
  <issue_number>부분을 지우고, 관련 이슈 번호를 작성
--->

- closes #250 

### 작업 분류

<!---
  버그 수정: 버그 수정에 대한 PR일 경우
  신규 기능 추가: 논의된 새로운 기능을 추가하였을 경우
  프로젝트 구조 변경: 디렉터리 구조나 코드 계층(추상화 레벨)이 변경된 경우
  코드 스타일 변경: 린트 규칙, 코딩 컨벤션 등의 변경
  문서 수정: 이슈 템플릿, README, CONTRIBUTE.md 등 프로젝트 관련 문서가 변경될 경우
--->

- [ ] 버그 수정
- [ ] 신규 기능 추가
- [x] 프로젝트 구조 변경
- [ ] 코드 스타일 변경
- [x] 기존 기능 개선
- [ ] 문서 수정

## PR을 통해 해결하려는 문제가 무엇인가요? 🚀
- 지원현황 -> 합/불 체크 시 아무런 피드백도 없기에 사용자는 체크가 잘 이루어졌는지 확인하기 어려웠습니다.
- 합/불 체크가 3곳(지원현황, 칸반보드, 관리자 합/불)에서 이루어지고 있는데 관련 로직들이 전부 따로 관리되고 있었기에 이를 통일화 합니다.

## PR에서 핵심적으로 변경된 부분이 어떤 부분인가요? 👀
- 기존 코드에서도 쿼리 무효화를 시켜주어 합/불 후 새로운 쿼리를 불러왔지만, 지원 현황에서의 데이터들은 모든 데이터를 불러와 useState의 setter를 통해 필터링 시켜 관리 되고 있었고, 상태 변화가 없었기에 합/불 피드백이 이루어지지 않았습니다.
-> 합/불 상태를 확인할 수 있는 로직을 만들고 합/불 상태를 CardApplicantStatusLabel 컴포넌트에서 전부 보여주게 변경

- optimistic updates 훅을 만들어 합/불 처리를 통일화.

<!---
  해결하려는 문제에 연관된 핵심 변경사항을 기술해주세요.
--->

## 핵심 변경사항 이외 추가적으로 변경된 사항이 있나요? ➕

<!---
  핵심 변경사항 이외 변경한 내용을 기술해주세요.
--->

## 추가적으로, 리뷰어가 리뷰하며 알아야 할 정보가 있나요? 🙌
- 모든 지원자들의 데이터를 불러와 필터링 해서 사용하기 보단, 결국에는 한 지원자의 정보만을 조회할 수 있는(합/불 상태 포함) api 가 필요하다고 생각합니다. 추 후 백엔드와 얘기해보고 새로 이슈 만들어 보겠습니다🫡
- 현재 만든 useApplicantId 훅 또한 모든 사용자를 가져와 필터링 후 사용하고 있습니다.

<!---
  참고링크, 리뷰 시 궁금한 점, 주의할 점 등등..
  리뷰어가 리뷰 전에 알아야 할 정보를 기술해주세요.
--->

## 이런 부분을 신경써서 봐주셨으면 좋겠어요. 🙋🏻‍♂️

<!---
  문제를 해결하며 궁금했던 점, 리뷰어와 같이 이야기 나눠보고 싶은 점
--->

## 체크리스트 ✅

- [x] `reviewers` 설정
- [x] `assignees` 설정
- [x] `label` 설정
