### PR TITLE
fix: 칸반보드 상세 페이지에서 구체적인 분야 불러오기

### DIFF
--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -88,6 +88,7 @@ export const APPLICANT_KEYS = [
   "field",
   "field1",
   "field2",
+  "specificField",
   "name",
   "contacted",
   "classOf",


### PR DESCRIPTION
## 관련 이슈

- closes #277 

### 작업 분류

<!---
  버그 수정: 버그 수정에 대한 PR일 경우
  신규 기능 추가: 논의된 새로운 기능을 추가하였을 경우
  프로젝트 구조 변경: 디렉터리 구조나 코드 계층(추상화 레벨)이 변경된 경우
  코드 스타일 변경: 린트 규칙, 코딩 컨벤션 등의 변경
  문서 수정: 이슈 템플릿, README, CONTRIBUTE.md 등 프로젝트 관련 문서가 변경될 경우
--->

- [x] 버그 수정
- [ ] 신규 기능 추가
- [ ] 프로젝트 구조 변경
- [ ] 코드 스타일 변경
- [ ] 기존 기능 개선
- [ ] 문서 수정

## PR을 통해 해결하려는 문제가 무엇인가요? 🚀

칸반 보드 상세 페이지에서 사용자가 입력한 구체적인 분야에 대한 내용이 렌더링되지 않는 문제입니다.

## PR에서 핵심적으로 변경된 부분이 어떤 부분인가요? 👀

칸반 보드 상세 페이지에서는 post 요청으로 request body에 담긴 필드에 대한 값을 받아오는데 구체적인 분야에 해당 하는 필드를 넣어주지 않았습니다.

## 핵심 변경사항 이외 추가적으로 변경된 사항이 있나요? ➕

상수 데이터에 구체적인 분야에 해당하는 필드 추가

## 체크리스트 ✅

- [x] `reviewers` 설정
- [x] `assignees` 설정
- [x] `label` 설정
