### PR TITLE
feat: 면접관 리스트 조회 API의 스팩 변경 및 면접관 리스트 조회 시 "현재 기수 면접관"만 조회하도록 수정

### DIFF
--- a/frontend/app/(WithNavbar)/admin/[generation]/page.tsx
+++ b/frontend/app/(WithNavbar)/admin/[generation]/page.tsx
@@ -3,7 +3,7 @@ import AdminBoard from "@/components/admin/Board.component";
 import AdminSearch from "@/components/admin/Search.component";
 import SortList from "@/components/common/SortList";
 import { ORDER_MENU } from "@/src/constants";
-import { getAllInterviewerWithOrder, getMyInfo } from "@/src/apis/interview";
+import { getInterviewer, getMyInfo } from "@/src/apis/interview";
 import getQueryClient from "@/src/functions/getQueryClient";
 
 interface AdminPageProps {
@@ -22,7 +22,7 @@ const AdminPage = async ({
   const queryClient = getQueryClient();
   await queryClient.prefetchQuery({
     queryKey: ["interviewers"],
-    queryFn: () => getAllInterviewerWithOrder(order),
+    queryFn: () => getInterviewer({ order }),
   });
 
   await queryClient.prefetchQuery({

--- a/frontend/app/(WithNavbar)/admin/[generation]/page.tsx
+++ b/frontend/app/(WithNavbar)/admin/[generation]/page.tsx
@@ -7,18 +7,12 @@ import { getInterviewer, getMyInfo } from "@/src/apis/interview";
 import getQueryClient from "@/src/functions/getQueryClient";
 
 interface AdminPageProps {
-  params: {
-    generation: string;
-  };
   searchParams: {
-    order: string;
+    order: (typeof ORDER_MENU.ADMIN)[number]["type"];
   };
 }
 
-const AdminPage = async ({
-  params,
-  searchParams: { order = "" },
-}: AdminPageProps) => {
+const AdminPage = async ({ searchParams: { order } }: AdminPageProps) => {
   const queryClient = getQueryClient();
   await queryClient.prefetchQuery({
     queryKey: ["interviewers"],

--- a/frontend/components/admin/Board.component.tsx
+++ b/frontend/components/admin/Board.component.tsx
@@ -56,7 +56,9 @@ const InterViewerUpdateButton = ({
 
 const AdminBoard = () => {
   const searchParams = useSearchParams();
-  const order = searchParams.get("order") || ORDER_MENU.ADMIN[0].type;
+  const order =
+    (searchParams.get("order") as (typeof ORDER_MENU.ADMIN)[number]["type"]) ||
+    ORDER_MENU.ADMIN[0].type;
 
   const {
     data: userData,

--- a/frontend/components/admin/Board.component.tsx
+++ b/frontend/components/admin/Board.component.tsx
@@ -3,7 +3,7 @@
 import {
   InterviewerReq,
   deleteInterviewer,
-  getAllInterviewerWithOrder,
+  getInterviewer,
   getMyInfo,
   putInterviewer,
 } from "@/src/apis/interview";
@@ -62,9 +62,7 @@ const AdminBoard = () => {
     data: userData,
     isLoading,
     isError,
-  } = useQuery(["interviewers", order], () =>
-    getAllInterviewerWithOrder(order)
-  );
+  } = useQuery(["interviewers", order], () => getInterviewer({ order }));
 
   const {
     data: myInfo,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,5 +54,6 @@
   },
   "devDependencies": {
     "cypress": "^13.13.3"
-  }
+  },
+  "packageManager": "pnpm@8.15.1+sha1.8adba2d20330c02d3856e18c4eb3819d1d3ca6aa"
 }

--- a/frontend/src/apis/applicant/index.ts
+++ b/frontend/src/apis/applicant/index.ts
@@ -1,4 +1,4 @@
-import { getAllInterviewerWithOrder } from "@/src/apis/interview";
+import { getInterviewer } from "@/src/apis/interview";
 import { APPLICANT_KEYS } from "@/src/constants";
 import { https } from "@/src/functions/axios";
 import { ApplicantPassState, getKanbanCards, KanbanCardReq } from "../kanban";
@@ -161,7 +161,10 @@ export interface ApplicantLabelReq {
 export const getApplicantLabel = async (
   id: string
 ): Promise<ApplicantLabelReq[]> => {
-  const allInterviewers = await getAllInterviewerWithOrder("name");
+  const allInterviewers = await getInterviewer({
+    order: "name",
+    roles: ["TF", "OPERATION", "PRESIDENT"],
+  });
 
   try {
     const { data } = await https.get<string[]>(`/applicants/${id}/labels`);

--- a/frontend/src/apis/interview/index.ts
+++ b/frontend/src/apis/interview/index.ts
@@ -1,6 +1,7 @@
 import { https } from "@/src/functions/axios";
 import { PageInfo } from "../applicant";
 import { type ApplicantPassState } from "../kanban";
+import { ORDER_MENU } from "@/src/constants";
 
 export type Role =
   | "ROLE_GUEST"
@@ -90,12 +91,18 @@ export const getInterviewer = async ({
   order,
   roles,
 }: {
-  order: string;
+  order?: "name" | "newest";
   roles?: RoleName[];
-}) => {
-  const { data } = await https.get<InterviewerReq[]>(
-    `/interviewers?order=${order}${roles && `&roles=${roles.join(",")}`}`
-  );
+} = {}) => {
+  const params = new URLSearchParams();
+  if (roles !== undefined) {
+    params.append("roles", roles.join(","));
+  }
+  if (order !== undefined) {
+    params.append("order", order);
+  }
+
+  const { data } = await https.get<InterviewerReq[]>(`/interviewers?${params}`);
 
   return data;
 };

--- a/frontend/src/apis/interview/index.ts
+++ b/frontend/src/apis/interview/index.ts
@@ -2,6 +2,14 @@ import { https } from "@/src/functions/axios";
 import { PageInfo } from "../applicant";
 import { type ApplicantPassState } from "../kanban";
 
+export type Role =
+  | "ROLE_GUEST"
+  | "ROLE_TF"
+  | "ROLE_OPERATION"
+  | "ROLE_PRESIDENT";
+
+export type RoleName = "GUEST" | "TF" | "OPERATION" | "PRESIDENT";
+
 export interface RecordsRes {
   applicantId: string;
   scores: number;
@@ -75,12 +83,18 @@ export interface InterviewerReq {
   id: number;
   name: string;
   year: number;
-  role: "ROLE_GUEST" | "ROLE_TF" | "ROLE_OPERATION" | "ROLE_PRESIDENT";
+  role: Role;
 }
 
-export const getAllInterviewerWithOrder = async (order: string) => {
+export const getInterviewer = async ({
+  order,
+  roles,
+}: {
+  order: string;
+  roles?: RoleName[];
+}) => {
   const { data } = await https.get<InterviewerReq[]>(
-    `/interviewers?order=${order}`
+    `/interviewers?order=${order}${roles && `&roles=${roles.join(",")}`}`
   );
 
   return data;
@@ -91,7 +105,7 @@ interface ApplicantReq {
   name: string;
   year: number;
   email: string;
-  role: "ROLE_GUEST" | "ROLE_TF" | "ROLE_OPERATION" | "ROLE_PRESIDENT";
+  role: Role;
 }
 
 export const getMyInfo = async () => {
@@ -101,7 +115,7 @@ export const getMyInfo = async () => {
 
 export interface putInterviewerReq {
   id: number;
-  role: "GUEST" | "TF" | "OPERATION" | "PRESIDENT";
+  role: RoleName;
 }
 
 export const putInterviewer = async ({ id, role }: putInterviewerReq) => {

--- a/frontend/src/apis/work/index.ts
+++ b/frontend/src/apis/work/index.ts
@@ -46,7 +46,7 @@ export const postWorkLabel = async (cardId: number) => {
 };
 
 export const getWorkLabel = async (cardId: number): Promise<WorkLabelReq[]> => {
-  const allInterviewers = await getInterviewer({ order: "" });
+  const allInterviewers = await getInterviewer();
 
   try {
     const { data } = await https.get<string[]>(`/cards/${cardId}/labels`);

--- a/frontend/src/apis/work/index.ts
+++ b/frontend/src/apis/work/index.ts
@@ -1,5 +1,5 @@
 import { https } from "@/src/functions/axios";
-import { getAllInterviewerWithOrder } from "../interview";
+import { getInterviewer } from "../interview";
 
 export interface Work {
   title: string;
@@ -46,7 +46,7 @@ export const postWorkLabel = async (cardId: number) => {
 };
 
 export const getWorkLabel = async (cardId: number): Promise<WorkLabelReq[]> => {
-  const allInterviewers = await getAllInterviewerWithOrder("");
+  const allInterviewers = await getInterviewer({ order: "" });
 
   try {
     const { data } = await https.get<string[]>(`/cards/${cardId}/labels`);


### PR DESCRIPTION
## 관련 이슈

- closes #279 

### 작업 분류

- [ ] 버그 수정
- [x] 신규 기능 추가
- [ ] 프로젝트 구조 변경
- [ ] 코드 스타일 변경
- [ ] 기존 기능 개선
- [ ] 문서 수정

## PR을 통해 해결하려는 문제가 무엇인가요? 🚀

기존에는 지원 현황 및 칸반보드 페이지에서 면접관 부분에 모든 사용자의 이름이 보였습니다. 
이번에 모든 사용자의 이름이 보이는 것이 아닌, 이번 신입모집에 참여한 사용자만 보이도록 수정하도록 TF팀의 요청이 있었습니다.
이에 따라서 (기존에 면접관 리스트를 가져오는 api에서 role에 따른 필터링 기능이 추가되었고, ) 필터링을 할 수 있도록 변경하였습니다. 

## PR에서 핵심적으로 변경된 부분이 어떤 부분인가요? 👀

면접관을 가져오는 getAllInterviewerWithOrder api 함수를 roles 쿼리 스트링을 받을 수 있도록 수정하였습니다. 
order만 받는 api가 아니므로, 이름을 getInterviewer로 변경하였습니다. 

## 핵심 변경사항 이외 추가적으로 변경된 사항이 있나요? ➕

api에서 반복되는 타입을 추가적으로 정의해주었습니다. 
```
export type Role =
  | "ROLE_GUEST"
  | "ROLE_TF"
  | "ROLE_OPERATION"
  | "ROLE_PRESIDENT";

export type RoleName = "GUEST" | "TF" | "OPERATION" | "PRESIDENT";
```

## 추가적으로, 리뷰어가 리뷰하며 알아야 할 정보가 있나요? 🙌

크게 없습니다!

## 이런 부분을 신경써서 봐주셨으면 좋겠어요. 🙋🏻‍♂️

혹시나 제가 놓친 부분이 있는지 확인 부탁드립니다! 🙇🏻‍♂️

## 체크리스트 ✅

- [ ] `reviewers` 설정
- [ ] `assignees` 설정
- [ ] `label` 설정
