### PR TITLE
feat: pagination page의 prefetch 로직

### DIFF
--- a/frontend/app/(WithNavbar)/interview/[generation]/page.tsx
+++ b/frontend/app/(WithNavbar)/interview/[generation]/page.tsx
@@ -1,7 +1,7 @@
 import SortList from "@/components/common/SortList";
 import Search from "@/components/common/Search";
 import { ORDER_MENU } from "@/src/constants";
-import InterviewerList from "@/components/interview/InterviewerList";
+import IntervieweeList from "@/components/interview/IntervieweeList";
 
 interface InterviewPageProps {
   params: {
@@ -16,7 +16,7 @@ const InterviewPage = ({ params: { generation } }: InterviewPageProps) => {
         <Search />
         <SortList sortList={ORDER_MENU.INTERVIEW} />
       </div>
-      <InterviewerList generation={generation} />
+      <IntervieweeList generation={generation} />
     </div>
   );
 };

--- a/frontend/components/applicant/ApplicantList.tsx
+++ b/frontend/components/applicant/ApplicantList.tsx
@@ -1,64 +1,20 @@
 "use client";
 
-import { useQuery, useQueryClient } from "@tanstack/react-query";
 import useApplicantPaginationParams from "../../src/hooks/applicant/useApplicantPaginationParams";
-import { getApplicantByPageWithGeneration } from "../../src/apis/applicant";
 import LoadingSpinner from "../common/LoadingSpinner";
 import ApplicantBoard from "./Board";
 import ApplicantPageNavbar from "./PageNavbar";
-import { useEffect } from "react";
+import { useApplicantsQuery } from "@/src/hooks/applicant";
 
 interface ApplicantListProps {
   generation: string;
 }
 
 const ApplicantList = ({ generation }: ApplicantListProps) => {
-  const { pageIndex, order, searchKeyword } = useApplicantPaginationParams();
-  const {
-    data: applicants,
-    status,
-    isPreviousData,
-  } = useQuery(
-    ["allApplicant", { generation, order, pageIndex, searchKeyword }],
-    () =>
-      getApplicantByPageWithGeneration(
-        +pageIndex,
-        generation,
-        order,
-        searchKeyword
-      ),
-    {
-      enabled: !!generation,
-      keepPreviousData: true,
-    }
-  );
-  const queryClient = useQueryClient();
-  /**
-   * 2025.03.18
-   * NOTE: 해당 prefetch는 client단의 prefetch입니다.
-   * 서버사이드에서의 prefetch를 하지 않은 이유는, 검색어에 따라 상태가 자주 바뀌기 때문입니다.
-   * 검색어가 변경될 때마다 서버에서 prefetch는 낭비일 수 있습니다. 따라서 client에서 prefetch를 하는 것이 좋다고 생각합니다.
-   */
-
-  useEffect(() => {
-    if (!applicants?.maxPage) return;
-    if (!isPreviousData && applicants.maxPage > +pageIndex) {
-      queryClient.prefetchQuery({
-        queryKey: [
-          "allApplicant",
-          { generation, order, pageIndex: `${+pageIndex + 1}`, searchKeyword },
-        ],
-        queryFn: () =>
-          getApplicantByPageWithGeneration(
-            +pageIndex + 1,
-            generation,
-            order,
-            searchKeyword
-          ),
-      });
-    }
-  }, [applicants, isPreviousData, pageIndex, queryClient]);
-
+  const { data: applicants, status } = useApplicantsQuery({
+    generation,
+    ...useApplicantPaginationParams(),
+  });
   if (status === "loading") {
     return <LoadingSpinner size="s" />;
   }

--- a/frontend/components/applicant/ApplicantList.tsx
+++ b/frontend/components/applicant/ApplicantList.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import useApplicantPaginationParams from "../../src/hooks/applicant/useApplicantPaginationParams";
 import { getApplicantByPageWithGeneration } from "../../src/apis/applicant";
 import LoadingSpinner from "../common/LoadingSpinner";
 import ApplicantBoard from "./Board";
 import ApplicantPageNavbar from "./PageNavbar";
+import { useEffect } from "react";
 
 interface ApplicantListProps {
   generation: string;
@@ -13,7 +14,11 @@ interface ApplicantListProps {
 
 const ApplicantList = ({ generation }: ApplicantListProps) => {
   const { pageIndex, order, searchKeyword } = useApplicantPaginationParams();
-  const { data: applicants, status } = useQuery(
+  const {
+    data: applicants,
+    status,
+    isPreviousData,
+  } = useQuery(
     ["allApplicant", { generation, order, pageIndex, searchKeyword }],
     () =>
       getApplicantByPageWithGeneration(
@@ -24,8 +29,35 @@ const ApplicantList = ({ generation }: ApplicantListProps) => {
       ),
     {
       enabled: !!generation,
+      keepPreviousData: true,
     }
   );
+  const queryClient = useQueryClient();
+  /**
+   * 2025.03.18
+   * NOTE: 해당 prefetch는 client단의 prefetch입니다.
+   * 서버사이드에서의 prefetch를 하지 않은 이유는, 검색어에 따라 상태가 자주 바뀌기 때문입니다.
+   * 검색어가 변경될 때마다 서버에서 prefetch는 낭비일 수 있습니다. 따라서 client에서 prefetch를 하는 것이 좋다고 생각합니다.
+   */
+
+  useEffect(() => {
+    if (!applicants?.maxPage) return;
+    if (!isPreviousData && applicants.maxPage > +pageIndex) {
+      queryClient.prefetchQuery({
+        queryKey: [
+          "allApplicant",
+          { generation, order, pageIndex: `${+pageIndex + 1}`, searchKeyword },
+        ],
+        queryFn: () =>
+          getApplicantByPageWithGeneration(
+            +pageIndex + 1,
+            generation,
+            order,
+            searchKeyword
+          ),
+      });
+    }
+  }, [applicants, isPreviousData, pageIndex, queryClient]);
 
   if (status === "loading") {
     return <LoadingSpinner size="s" />;

--- a/frontend/components/applicant/PageNavbar.tsx
+++ b/frontend/components/applicant/PageNavbar.tsx
@@ -15,7 +15,6 @@ const ApplicantPageNavbar = ({
 
   const queryParams = { search: searchKeyword, order };
 
-  // Search 넣어야 함!!!
   return (
     <PageNavbarComponent
       maxLength={maxPage}

--- a/frontend/components/applicant/PageNavbar.tsx
+++ b/frontend/components/applicant/PageNavbar.tsx
@@ -1,7 +1,6 @@
 "use client";
 import PageNavbarComponent from "../common/PageNavbar.component";
-import { useCreateQueryString } from "@/src/hooks/useCreateQueryString";
-import useApplicantPaginationParams from "../../src/hooks/applicant/useApplicantPaginationParams";
+import useApplicantPaginationParams from "@/src/hooks/applicant/useApplicantPaginationParams";
 
 type ApplicantPageNavbarProps = {
   generation: string;
@@ -12,22 +11,17 @@ const ApplicantPageNavbar = ({
   generation,
   maxPage,
 }: ApplicantPageNavbarProps) => {
-  const { pageIndex, type, order, searchKeyword } =
-    useApplicantPaginationParams();
+  const { pageIndex, order, searchKeyword } = useApplicantPaginationParams();
 
-  const queryParams = { search: searchKeyword, type, order };
-
-  const { createQueryString } = useCreateQueryString();
+  const queryParams = { search: searchKeyword, order };
 
   // Search 넣어야 함!!!
   return (
     <PageNavbarComponent
       maxLength={maxPage}
       page={+pageIndex}
-      url={`/applicant/${generation}?${createQueryString(
-        Object.keys(queryParams),
-        Object.values(queryParams)
-      )}`}
+      url={`/applicant/${generation}`}
+      query={queryParams}
     />
   );
 };

--- a/frontend/components/common/PageNavbar.component.tsx
+++ b/frontend/components/common/PageNavbar.component.tsx
@@ -1,22 +1,29 @@
+import { ApplicantPaginationParams } from "@/src/hooks/applicant/useApplicantPaginationParams";
+import Link from "next/link";
+
+interface PageNavbarComponentProps {
+  page: number;
+  url: string;
+  query: Partial<ApplicantPaginationParams>;
+  maxLength: number;
+}
+
 const PageNavbarComponent = ({
   page,
   url,
+  query,
   maxLength,
-}: {
-  page: number;
-  url: string;
-  maxLength: number;
-}) => {
+}: PageNavbarComponentProps) => {
   return (
     <div className="flex w-full justify-end gap-4 mt-16">
       {Array.from({ length: maxLength }).map((_, i) => (
-        <a
+        <Link
           key={i}
-          href={url + `&page=${i + 1}`}
+          href={{ pathname: url, query: { ...query, page: i + 1 } }}
           className={i + 1 === page ? "p-3" : "text-secondary-100 p-3"}
         >
           {i + 1}
-        </a>
+        </Link>
       ))}
     </div>
   );

--- a/frontend/components/common/PageNavbar.component.tsx
+++ b/frontend/components/common/PageNavbar.component.tsx
@@ -19,7 +19,10 @@ const PageNavbarComponent = ({
       {Array.from({ length: maxLength }).map((_, i) => (
         <Link
           key={i}
-          href={{ pathname: url, query: { ...query, page: i + 1 } }}
+          href={{
+            pathname: url,
+            query: { ...query, search: query.searchKeyword, page: i + 1 },
+          }}
           className={i + 1 === page ? "p-3" : "text-secondary-100 p-3"}
         >
           {i + 1}

--- a/frontend/components/interview/IntervieweeList.tsx
+++ b/frontend/components/interview/IntervieweeList.tsx
@@ -1,22 +1,22 @@
 "use client";
 import InterviewBoard from "./Board";
-import InterviewPageNavbar from "./PageNavbar";
+import IntervieweePageNavbar from "./PageNavbar";
 import LoadingSpinner from "../common/LoadingSpinner";
 import { removeAll } from "@/src/functions/replacer";
 import { CHARACTERS } from "@/src/constants";
 import {
   useAllInterviewRecordQuery,
-  useInterviewerPaginationParams,
+  useIntervieweePaginationParams,
 } from "@/src/hooks/interview";
 
-interface InterviewerListProps {
+interface IntervieweeListProps {
   generation: string;
 }
 
-const InterviewerList = ({ generation }: InterviewerListProps) => {
-  const { data: interviewers, status } = useAllInterviewRecordQuery({
+const IntervieweeList = ({ generation }: IntervieweeListProps) => {
+  const { data: interviewees, status } = useAllInterviewRecordQuery({
     generation,
-    ...useInterviewerPaginationParams(),
+    ...useIntervieweePaginationParams(),
   });
 
   if (status === "loading") {
@@ -31,7 +31,7 @@ const InterviewerList = ({ generation }: InterviewerListProps) => {
     return <div>에러가 발생하였습니다. 잠시 후 다시 시도해보세요.</div>;
   }
 
-  const interviewRecords = interviewers.records.map((value) => {
+  const interviewRecords = interviewees.records.map((value) => {
     return {
       id: value.applicantId,
       title: value.name,
@@ -52,12 +52,12 @@ const InterviewerList = ({ generation }: InterviewerListProps) => {
   return (
     <>
       <InterviewBoard interviewRecords={interviewRecords} />
-      <InterviewPageNavbar
+      <IntervieweePageNavbar
         generation={generation}
-        maxPage={interviewers.maxPage}
+        maxPage={interviewees.maxPage}
       />
     </>
   );
 };
 
-export default InterviewerList;
+export default IntervieweeList;

--- a/frontend/components/interview/InterviewerList.tsx
+++ b/frontend/components/interview/InterviewerList.tsx
@@ -1,73 +1,23 @@
 "use client";
-
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import useInterviewerPaginationParams from "../../src/hooks/interview/useInterviewerPaginationParams";
-import { getInterviewRecordByPageWithOrder } from "../../src/apis/interview";
 import InterviewBoard from "./Board";
 import InterviewPageNavbar from "./PageNavbar";
 import LoadingSpinner from "../common/LoadingSpinner";
-import { removeAll } from "../../src/functions/replacer";
-import { CHARACTERS } from "../../src/constants";
-import { useEffect } from "react";
+import { removeAll } from "@/src/functions/replacer";
+import { CHARACTERS } from "@/src/constants";
+import {
+  useAllInterviewRecordQuery,
+  useInterviewerPaginationParams,
+} from "@/src/hooks/interview";
 
 interface InterviewerListProps {
   generation: string;
 }
 
 const InterviewerList = ({ generation }: InterviewerListProps) => {
-  const { pageIndex, order, searchKeyword } = useInterviewerPaginationParams();
-
-  const {
-    data: interview,
-    status,
-    isPreviousData,
-  } = useQuery({
-    queryKey: [
-      "allInterviewRecord",
-      { pageIndex, order, generation, searchKeyword },
-    ],
-    queryFn: () =>
-      getInterviewRecordByPageWithOrder({
-        page: +pageIndex,
-        order: order,
-        year: generation,
-        searchKeyword,
-      }),
-  });
-
-  /**
-   * 2025.03.18
-   * NOTE: 해당 prefetch는 client단의 prefetch입니다.
-   * 서버사이드에서의 prefetch를 하지 않은 이유는, 검색어에 따라 상태가 자주 바뀌기 때문입니다.
-   * 검색어가 변경될 때마다 서버에서 prefetch는 낭비일 수 있습니다. 따라서 client에서 prefetch를 하는 것이 좋다고 생각합니다.
-   */
-  const queryClient = useQueryClient();
-
-  useEffect(() => {
-    if (!interview?.maxPage) return;
-    if (!isPreviousData && interview.maxPage > +pageIndex) {
-      queryClient.prefetchQuery({
-        queryKey: [
-          "allInterviewRecord",
-          { pageIndex: `${+pageIndex + 1}`, order, generation, searchKeyword },
-        ],
-        queryFn: () =>
-          getInterviewRecordByPageWithOrder({
-            page: +pageIndex + 1,
-            order: order,
-            year: generation,
-            searchKeyword,
-          }),
-      });
-    }
-  }, [
-    interview?.maxPage,
-    pageIndex,
-    order,
+  const { data: interviewers, status } = useAllInterviewRecordQuery({
     generation,
-    searchKeyword,
-    queryClient,
-  ]);
+    ...useInterviewerPaginationParams(),
+  });
 
   if (status === "loading") {
     return (
@@ -81,7 +31,7 @@ const InterviewerList = ({ generation }: InterviewerListProps) => {
     return <div>에러가 발생하였습니다. 잠시 후 다시 시도해보세요.</div>;
   }
 
-  const interviewRecords = interview.records.map((value) => {
+  const interviewRecords = interviewers.records.map((value) => {
     return {
       id: value.applicantId,
       title: value.name,
@@ -104,7 +54,7 @@ const InterviewerList = ({ generation }: InterviewerListProps) => {
       <InterviewBoard interviewRecords={interviewRecords} />
       <InterviewPageNavbar
         generation={generation}
-        maxPage={interview.maxPage}
+        maxPage={interviewers.maxPage}
       />
     </>
   );

--- a/frontend/components/interview/InterviewerList.tsx
+++ b/frontend/components/interview/InterviewerList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import useInterviewerPaginationParams from "../../src/hooks/interview/useInterviewerPaginationParams";
 import { getInterviewRecordByPageWithOrder } from "../../src/apis/interview";
 import InterviewBoard from "./Board";
@@ -8,6 +8,7 @@ import InterviewPageNavbar from "./PageNavbar";
 import LoadingSpinner from "../common/LoadingSpinner";
 import { removeAll } from "../../src/functions/replacer";
 import { CHARACTERS } from "../../src/constants";
+import { useEffect } from "react";
 
 interface InterviewerListProps {
   generation: string;
@@ -16,7 +17,11 @@ interface InterviewerListProps {
 const InterviewerList = ({ generation }: InterviewerListProps) => {
   const { pageIndex, order, searchKeyword } = useInterviewerPaginationParams();
 
-  const { data: interview, status } = useQuery({
+  const {
+    data: interview,
+    status,
+    isPreviousData,
+  } = useQuery({
     queryKey: [
       "allInterviewRecord",
       { pageIndex, order, generation, searchKeyword },
@@ -29,6 +34,40 @@ const InterviewerList = ({ generation }: InterviewerListProps) => {
         searchKeyword,
       }),
   });
+
+  /**
+   * 2025.03.18
+   * NOTE: 해당 prefetch는 client단의 prefetch입니다.
+   * 서버사이드에서의 prefetch를 하지 않은 이유는, 검색어에 따라 상태가 자주 바뀌기 때문입니다.
+   * 검색어가 변경될 때마다 서버에서 prefetch는 낭비일 수 있습니다. 따라서 client에서 prefetch를 하는 것이 좋다고 생각합니다.
+   */
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!interview?.maxPage) return;
+    if (!isPreviousData && interview.maxPage > +pageIndex) {
+      queryClient.prefetchQuery({
+        queryKey: [
+          "allInterviewRecord",
+          { pageIndex: `${+pageIndex + 1}`, order, generation, searchKeyword },
+        ],
+        queryFn: () =>
+          getInterviewRecordByPageWithOrder({
+            page: +pageIndex + 1,
+            order: order,
+            year: generation,
+            searchKeyword,
+          }),
+      });
+    }
+  }, [
+    interview?.maxPage,
+    pageIndex,
+    order,
+    generation,
+    searchKeyword,
+    queryClient,
+  ]);
 
   if (status === "loading") {
     return (

--- a/frontend/components/interview/PageNavbar.tsx
+++ b/frontend/components/interview/PageNavbar.tsx
@@ -1,17 +1,17 @@
 "use client";
+import { useIntervieweePaginationParams } from "@/src/hooks/interview";
 import PageNavbarComponent from "../common/PageNavbar.component";
-import useInterviewerPaginationParams from "../../src/hooks/interview/useInterviewerPaginationParams";
 
-type InterviewPageNavbarProps = {
+type IntervieweePageNavbarProps = {
   maxPage: number;
   generation: string;
 };
 
-const InterviewPageNavbar = ({
+const IntervieweePageNavbar = ({
   maxPage,
   generation,
-}: InterviewPageNavbarProps) => {
-  const { pageIndex, order, searchKeyword } = useInterviewerPaginationParams();
+}: IntervieweePageNavbarProps) => {
+  const { pageIndex, order, searchKeyword } = useIntervieweePaginationParams();
 
   return (
     <PageNavbarComponent
@@ -23,4 +23,4 @@ const InterviewPageNavbar = ({
   );
 };
 
-export default InterviewPageNavbar;
+export default IntervieweePageNavbar;

--- a/frontend/components/interview/PageNavbar.tsx
+++ b/frontend/components/interview/PageNavbar.tsx
@@ -1,6 +1,5 @@
 "use client";
 import PageNavbarComponent from "../common/PageNavbar.component";
-import { useCreateQueryString } from "@/src/hooks/useCreateQueryString";
 import useInterviewerPaginationParams from "../../src/hooks/interview/useInterviewerPaginationParams";
 
 type InterviewPageNavbarProps = {

--- a/frontend/components/interview/PageNavbar.tsx
+++ b/frontend/components/interview/PageNavbar.tsx
@@ -12,21 +12,14 @@ const InterviewPageNavbar = ({
   maxPage,
   generation,
 }: InterviewPageNavbarProps) => {
-  const { pageIndex, type, order, searchKeyword } =
-    useInterviewerPaginationParams();
-
-  const queryParams = { type, order, search: searchKeyword };
-
-  const { createQueryString } = useCreateQueryString();
+  const { pageIndex, order, searchKeyword } = useInterviewerPaginationParams();
 
   return (
     <PageNavbarComponent
       maxLength={maxPage}
       page={+pageIndex}
-      url={`/interview/${generation}?${createQueryString(
-        Object.keys(queryParams),
-        Object.values(queryParams)
-      )}`}
+      url={`/interview/${generation}`}
+      query={{ order, searchKeyword }}
     />
   );
 };

--- a/frontend/src/hooks/applicant/index.ts
+++ b/frontend/src/hooks/applicant/index.ts
@@ -1,0 +1,2 @@
+export { default as useApplicantPaginationParams } from "./useApplicantPaginationParams";
+export { default as useApplicantsQuery } from "./useApplicantsQuery";

--- a/frontend/src/hooks/applicant/useApplicantPaginationParams.ts
+++ b/frontend/src/hooks/applicant/useApplicantPaginationParams.ts
@@ -1,14 +1,19 @@
 import { useSearchParams } from "next/navigation";
 import { ORDER_MENU } from "../../constants";
 
-const useApplicantPaginationParams = () => {
+export interface ApplicantPaginationParams {
+  pageIndex: string;
+  order: string;
+  searchKeyword: string;
+}
+
+const useApplicantPaginationParams: () => ApplicantPaginationParams = () => {
   const searchParams = useSearchParams();
   const pageIndex = searchParams.get("page") || "1";
   const order = searchParams.get("order") || ORDER_MENU.APPLICANT[0].type;
   const searchKeyword = searchParams.get("search") || "";
-  const type = searchParams.get("type") ?? "list";
 
-  return { pageIndex, order, searchKeyword, type };
+  return { pageIndex, order, searchKeyword };
 };
 
 export default useApplicantPaginationParams;

--- a/frontend/src/hooks/applicant/useApplicantsQuery.ts
+++ b/frontend/src/hooks/applicant/useApplicantsQuery.ts
@@ -4,11 +4,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { type ApplicantPaginationParams } from "./useApplicantPaginationParams";
 import { getApplicantByPageWithGeneration } from "@/src/apis/applicant";
 
-interface UseApplicantsQueryProps
-  extends Pick<
-    ApplicantPaginationParams,
-    "order" | "pageIndex" | "searchKeyword"
-  > {
+interface UseApplicantsQueryProps extends ApplicantPaginationParams {
   generation: string;
 }
 

--- a/frontend/src/hooks/applicant/useApplicantsQuery.ts
+++ b/frontend/src/hooks/applicant/useApplicantsQuery.ts
@@ -1,0 +1,67 @@
+import { useEffect } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { type ApplicantPaginationParams } from "./useApplicantPaginationParams";
+import { getApplicantByPageWithGeneration } from "@/src/apis/applicant";
+
+interface UseApplicantsQueryProps
+  extends Pick<
+    ApplicantPaginationParams,
+    "order" | "pageIndex" | "searchKeyword"
+  > {
+  generation: string;
+}
+
+const useApplicantsQuery = ({
+  generation,
+  pageIndex,
+  order,
+  searchKeyword,
+}: UseApplicantsQueryProps) => {
+  const currentPage = +pageIndex;
+
+  const query = useQuery({
+    queryKey: ["allApplicant", { generation, order, pageIndex, searchKeyword }],
+    queryFn: () =>
+      getApplicantByPageWithGeneration(
+        currentPage,
+        generation,
+        order,
+        searchKeyword
+      ),
+    enabled: !!generation,
+    keepPreviousData: true,
+  });
+  const queryClient = useQueryClient();
+
+  /**
+   * 2025.03.18
+   * NOTE: 해당 prefetch는 client단의 prefetch입니다.
+   * 서버사이드에서의 prefetch를 하지 않은 이유는, 검색어에 따라 상태가 자주 바뀌기 때문입니다.
+   * 검색어가 변경될 때마다 서버에서 prefetch는 낭비일 수 있습니다. 따라서 client에서 prefetch를 하는 것이 좋다고 생각합니다.
+   */
+
+  useEffect(() => {
+    const nextPage = currentPage + 1;
+    if (!query.data) return;
+    if (!query.isPreviousData && query.data.maxPage > currentPage) {
+      queryClient.prefetchQuery({
+        queryKey: [
+          "allApplicant",
+          { generation, order, pageIndex: `${nextPage}`, searchKeyword },
+        ],
+        queryFn: () =>
+          getApplicantByPageWithGeneration(
+            nextPage,
+            generation,
+            order,
+            searchKeyword
+          ),
+      });
+    }
+  }, [query.data, query.isPreviousData, pageIndex, queryClient]);
+
+  return query;
+};
+
+export default useApplicantsQuery;

--- a/frontend/src/hooks/interview/index.ts
+++ b/frontend/src/hooks/interview/index.ts
@@ -1,2 +1,2 @@
-export { default as useInterviewerPaginationParams } from "./useInterviewerPaginationParams";
+export { default as useIntervieweePaginationParams } from "./useIntervieweePaginationParams";
 export { default as useAllInterviewRecordQuery } from "./useAllInterviewRecordQuery";

--- a/frontend/src/hooks/interview/index.ts
+++ b/frontend/src/hooks/interview/index.ts
@@ -1,0 +1,2 @@
+export { default as useInterviewerPaginationParams } from "./useInterviewerPaginationParams";
+export { default as useAllInterviewRecordQuery } from "./useAllInterviewRecordQuery";

--- a/frontend/src/hooks/interview/useAllInterviewRecordQuery.ts
+++ b/frontend/src/hooks/interview/useAllInterviewRecordQuery.ts
@@ -1,0 +1,77 @@
+import { useEffect } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { getInterviewRecordByPageWithOrder } from "@/src/apis/interview";
+import { type InterviewerPaginationParams } from "./useInterviewerPaginationParams";
+
+interface UseAllInterviewRecordQueryProps
+  extends Pick<
+    InterviewerPaginationParams,
+    "pageIndex" | "order" | "searchKeyword"
+  > {
+  generation: string;
+}
+
+const useAllInterviewRecordQuery = ({
+  generation,
+  pageIndex,
+  order,
+  searchKeyword,
+}: UseAllInterviewRecordQueryProps) => {
+  const queryKeys = [
+    "allInterviewRecord",
+    { pageIndex, order, generation, searchKeyword },
+  ];
+  const currentPage = +pageIndex;
+
+  const query = useQuery({
+    queryKey: queryKeys,
+    queryFn: () =>
+      getInterviewRecordByPageWithOrder({
+        page: currentPage,
+        order: order,
+        year: generation,
+        searchKeyword,
+      }),
+  });
+
+  const queryClient = useQueryClient();
+
+  /**
+   * 2025.03.18
+   * NOTE: 해당 prefetch는 client단의 prefetch입니다.
+   * 서버사이드에서의 prefetch를 하지 않은 이유는, 검색어에 따라 상태가 자주 바뀌기 때문입니다.
+   * 검색어가 변경될 때마다 서버에서 prefetch는 낭비일 수 있습니다. 따라서 client에서 prefetch를 하는 것이 좋다고 생각합니다.
+   */
+  useEffect(() => {
+    const nextPage = currentPage + 1;
+    if (!query.data) return;
+    if (!query.isPreviousData && query.data.maxPage > currentPage) {
+      queryClient.prefetchQuery({
+        queryKey: [
+          "allInterviewRecord",
+          { pageIndex: `${nextPage}`, order, generation, searchKeyword },
+        ],
+        queryFn: () =>
+          getInterviewRecordByPageWithOrder({
+            page: nextPage,
+            order: order,
+            year: generation,
+            searchKeyword,
+          }),
+      });
+    }
+  }, [
+    query.data,
+    query.isPreviousData,
+    currentPage,
+    order,
+    generation,
+    searchKeyword,
+    queryClient,
+  ]);
+
+  return query;
+};
+
+export default useAllInterviewRecordQuery;

--- a/frontend/src/hooks/interview/useAllInterviewRecordQuery.ts
+++ b/frontend/src/hooks/interview/useAllInterviewRecordQuery.ts
@@ -2,11 +2,11 @@ import { useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { getInterviewRecordByPageWithOrder } from "@/src/apis/interview";
-import { type InterviewerPaginationParams } from "./useInterviewerPaginationParams";
+import { type IntervieweePaginationParams } from "./useIntervieweePaginationParams";
 
 interface UseAllInterviewRecordQueryProps
   extends Pick<
-    InterviewerPaginationParams,
+    IntervieweePaginationParams,
     "pageIndex" | "order" | "searchKeyword"
   > {
   generation: string;

--- a/frontend/src/hooks/interview/useAllInterviewRecordQuery.ts
+++ b/frontend/src/hooks/interview/useAllInterviewRecordQuery.ts
@@ -33,6 +33,7 @@ const useAllInterviewRecordQuery = ({
         year: generation,
         searchKeyword,
       }),
+    keepPreviousData: true,
   });
 
   const queryClient = useQueryClient();

--- a/frontend/src/hooks/interview/useAllInterviewRecordQuery.ts
+++ b/frontend/src/hooks/interview/useAllInterviewRecordQuery.ts
@@ -4,11 +4,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getInterviewRecordByPageWithOrder } from "@/src/apis/interview";
 import { type IntervieweePaginationParams } from "./useIntervieweePaginationParams";
 
-interface UseAllInterviewRecordQueryProps
-  extends Pick<
-    IntervieweePaginationParams,
-    "pageIndex" | "order" | "searchKeyword"
-  > {
+interface UseAllInterviewRecordQueryProps extends IntervieweePaginationParams {
   generation: string;
 }
 
@@ -18,14 +14,17 @@ const useAllInterviewRecordQuery = ({
   order,
   searchKeyword,
 }: UseAllInterviewRecordQueryProps) => {
-  const queryKeys = [
+  // TODO: 나중에 밖으로 분리해내거나, query-key-factory 사용으로 변경할 것.
+  // 지금은 의존성이 이 페이지 밖에 없어서 상관없으나, 확장되면 문제가 발생할 수도 있음.
+  const allInterviewRecord = (page: number) => [
     "allInterviewRecord",
-    { pageIndex, order, generation, searchKeyword },
+    { page, order, generation, searchKeyword },
   ];
+
   const currentPage = +pageIndex;
 
   const query = useQuery({
-    queryKey: queryKeys,
+    queryKey: allInterviewRecord(currentPage),
     queryFn: () =>
       getInterviewRecordByPageWithOrder({
         page: currentPage,
@@ -49,10 +48,7 @@ const useAllInterviewRecordQuery = ({
     if (!query.data) return;
     if (!query.isPreviousData && query.data.maxPage > currentPage) {
       queryClient.prefetchQuery({
-        queryKey: [
-          "allInterviewRecord",
-          { pageIndex: `${nextPage}`, order, generation, searchKeyword },
-        ],
+        queryKey: allInterviewRecord(nextPage),
         queryFn: () =>
           getInterviewRecordByPageWithOrder({
             page: nextPage,

--- a/frontend/src/hooks/interview/useIntervieweePaginationParams.ts
+++ b/frontend/src/hooks/interview/useIntervieweePaginationParams.ts
@@ -2,13 +2,13 @@ import { useSearchParams } from "next/navigation";
 import { ORDER_MENU } from "../../constants";
 
 // TODO: ApplicantPaginationParams와 같은 타입임.
-export interface InterviewerPaginationParams {
+export interface IntervieweePaginationParams {
   pageIndex: string;
   order: string;
   searchKeyword: string;
 }
 
-const useInterviewerPaginationParams: () => InterviewerPaginationParams =
+const useIntervieweePaginationParams: () => IntervieweePaginationParams =
   () => {
     const searchParams = useSearchParams();
     const pageIndex = searchParams.get("page") || "1";
@@ -18,4 +18,4 @@ const useInterviewerPaginationParams: () => InterviewerPaginationParams =
     return { pageIndex, order, searchKeyword };
   };
 
-export default useInterviewerPaginationParams;
+export default useIntervieweePaginationParams;

--- a/frontend/src/hooks/interview/useInterviewerPaginationParams.ts
+++ b/frontend/src/hooks/interview/useInterviewerPaginationParams.ts
@@ -1,14 +1,21 @@
 import { useSearchParams } from "next/navigation";
 import { ORDER_MENU } from "../../constants";
 
-const useInterviewerPaginationParams = () => {
-  const searchParams = useSearchParams();
-  const pageIndex = searchParams.get("page") || "1";
-  const order = searchParams.get("order") || ORDER_MENU.INTERVIEW[0].type;
-  const searchKeyword = searchParams.get("search") || "";
-  const type = searchParams.get("type") ?? "list";
+// TODO: ApplicantPaginationParams와 같은 타입임.
+export interface InterviewerPaginationParams {
+  pageIndex: string;
+  order: string;
+  searchKeyword: string;
+}
 
-  return { pageIndex, order, searchKeyword, type };
-};
+const useInterviewerPaginationParams: () => InterviewerPaginationParams =
+  () => {
+    const searchParams = useSearchParams();
+    const pageIndex = searchParams.get("page") || "1";
+    const order = searchParams.get("order") || ORDER_MENU.INTERVIEW[0].type;
+    const searchKeyword = searchParams.get("search") || "";
+
+    return { pageIndex, order, searchKeyword };
+  };
 
 export default useInterviewerPaginationParams;


### PR DESCRIPTION
## 관련 이슈


- closes #254 

### 작업 분류

<!---
  버그 수정: 버그 수정에 대한 PR일 경우
  신규 기능 추가: 논의된 새로운 기능을 추가하였을 경우
  프로젝트 구조 변경: 디렉터리 구조나 코드 계층(추상화 레벨)이 변경된 경우
  코드 스타일 변경: 린트 규칙, 코딩 컨벤션 등의 변경
  문서 수정: 이슈 템플릿, README, CONTRIBUTE.md 등 프로젝트 관련 문서가 변경될 경우
--->

- [ ] 버그 수정
- [ ] 신규 기능 추가
- [ ] 프로젝트 구조 변경
- [x] 코드 스타일 변경
- [x] 기존 기능 개선
- [ ] 문서 수정

## PR을 통해 해결하려는 문제가 무엇인가요? 🚀

기존에 신입모집 지원 현황 페이지와, 신입모집 면접 기록 페이지에서 페이지 이동을 하게되면 깜빡임 현상이 있었습니다.

이는 이후 탐색 페이지를 prefetch하지 않아 loading 상태로 인해 발생하는 문제 였습니다.

이에 따라 #254 에서 @smb0123 님이 제공해주신 Link 태그와 곁들여,

client 단에서의 prefetch도 진행하였습니다.

### 💡 왜 Server에서 prefetch를 하지 않았나요?

#67 PR을 보면 배경님이 구현해주신 좋은 SSR 예시가 있습니다. 제가 구현한 컴포넌트에도 SSR prefetch를 할 수 있지만,
저는 client prefetch로 구현하였습니다. 이유는 만약 SSR prefetch를 하게된다면 검색어 쿼리로 인해 필요 이상으로 페이지를 요청보내고 받을 수 있다고 생각했기 때문입니다.
따라서 서버에서 그려주는 건 레이아웃 부분만 있어도 충분하다고 판단하였습니다. 더 좋은 의견이 있다면 PR에 달아주세요.

## PR에서 핵심적으로 변경된 부분이 어떤 부분인가요? 👀

기존 훅 로직을 적당한 계층에 맞게 추상화 하였습니다.

## 핵심 변경사항 이외 추가적으로 변경된 사항이 있나요? ➕

코드 구조를 제 편한대로 구현하였는데, 의문점이나 개선점 있다면 주저없이 댓글 달아주세요!

## 추가적으로, 리뷰어가 리뷰하며 알아야 할 정보가 있나요? 🙌

가급적 최종 시작 전에 Merge된다면 감사드리겠습니다 :)

## 이런 부분을 신경써서 봐주셨으면 좋겠어요. 🙋🏻‍♂️

No response

## 체크리스트 ✅

- [x] `reviewers` 설정
- [x] `assignees` 설정
- [x] `label` 설정
