### PR TITLE
refactor: ApplicantResource 에서 합/불 선택 시 선택된 버튼 disabled

### DIFF
--- a/frontend/components/applicant/applicantNode/CustomResource.component.tsx
+++ b/frontend/components/applicant/applicantNode/CustomResource.component.tsx
@@ -96,9 +96,8 @@ const ApplicantResource = ({
               disabled={isPass}
               onClick={onClickPass}
               className={`${
-                isPass &&
-                "disabled:bg-zinc-300 disabled:cursor-not-allowed disabled:hover:bg-zinc-300"
-              }  w-20 h-20 bg-sky-300 hover:bg-sky-400 rounded-xl`}
+                isPass && "disabled:bg-zinc-200 disabled:cursor-not-allowed "
+              }  w-20 h-20 bg-zinc-200 hover:bg-sky-400 rounded-xl`}
             >
               합격
             </button>
@@ -106,9 +105,8 @@ const ApplicantResource = ({
               disabled={isNonPass}
               onClick={onClickNonPass}
               className={` ${
-                isNonPass &&
-                "disabled:bg-zinc-300 disabled:cursor-not-allowed disabled:hover:bg-zinc-300"
-              } w-20 h-20 bg-rose-300 hover:bg-rose-400 rounded-xl`}
+                isNonPass && "disabled:bg-zinc-200 disabled:cursor-not-allowed"
+              } w-20 h-20 bg-zinc-200 hover:bg-sky-400 rounded-xl`}
             >
               불합격
             </button>

--- a/frontend/components/applicant/applicantNode/CustomResource.component.tsx
+++ b/frontend/components/applicant/applicantNode/CustomResource.component.tsx
@@ -69,6 +69,11 @@ const ApplicantResource = ({
     return <div>에러 발생</div>;
   }
 
+  const passState = getPassState(initialState);
+
+  const isPass = passState === "first-passed" || passState === "final-passed";
+  const isNonPass = passState === "non-passed";
+
   return (
     <>
       <div className="flex justify-between items-center">
@@ -77,7 +82,7 @@ const ApplicantResource = ({
             <Txt className="text-xl text-secondary-200 font-medium">
               {applicantDataFinder(data, "major")}
             </Txt>
-            <CardApplicantStatusLabel passState={getPassState(initialState)} />
+            <CardApplicantStatusLabel passState={passState} />
           </div>
           <Txt typography="h2">{`[${applicantDataFinder(
             data,
@@ -88,14 +93,22 @@ const ApplicantResource = ({
           myInfo.role === "ROLE_PRESIDENT") && (
           <div className="flex gap-5">
             <button
+              disabled={isPass}
               onClick={onClickPass}
-              className="bg-zinc-200 w-20 h-20 hover:bg-sky-400 rounded-xl"
+              className={`${
+                isPass &&
+                "disabled:bg-zinc-300 disabled:cursor-not-allowed disabled:hover:bg-zinc-300"
+              }  w-20 h-20 bg-sky-300 hover:bg-sky-400 rounded-xl`}
             >
               합격
             </button>
             <button
+              disabled={isNonPass}
               onClick={onClickNonPass}
-              className="bg-zinc-200 w-20 h-20 hover:bg-sky-400 rounded-xl"
+              className={` ${
+                isNonPass &&
+                "disabled:bg-zinc-300 disabled:cursor-not-allowed disabled:hover:bg-zinc-300"
+              } w-20 h-20 bg-rose-300 hover:bg-rose-400 rounded-xl`}
             >
               불합격
             </button>


### PR DESCRIPTION
## 관련 이슈

<!---
  <issue_number>부분을 지우고, 관련 이슈 번호를 작성
--->

- closes #285 

### 작업 분류

<!---
  버그 수정: 버그 수정에 대한 PR일 경우
  신규 기능 추가: 논의된 새로운 기능을 추가하였을 경우
  프로젝트 구조 변경: 디렉터리 구조나 코드 계층(추상화 레벨)이 변경된 경우
  코드 스타일 변경: 린트 규칙, 코딩 컨벤션 등의 변경
  문서 수정: 이슈 템플릿, README, CONTRIBUTE.md 등 프로젝트 관련 문서가 변경될 경우
--->

- [ ] 버그 수정
- [ ] 신규 기능 추가
- [ ] 프로젝트 구조 변경
- [ ] 코드 스타일 변경
- [x] 기존 기능 개선
- [ ] 문서 수정

## PR을 통해 해결하려는 문제가 무엇인가요? 🚀

<!---
  이 PR은 어떤 문제를 해결하는지, 리뷰어가 알 수 있게 기술해주세요.
--->

https://github.com/user-attachments/assets/864561e2-b730-4f57-9af8-50d585448dd5

1차 합격, 최종 합격일 때 합격 버튼 disabled 되도록 , 그리고 불합격일 때 불합격 버튼 disabled 되도록 수정했습니다.

컨벤션 못 맞춘 부분 있으면 알려주세요!

## PR에서 핵심적으로 변경된 부분이 어떤 부분인가요? 👀

<!---
  해결하려는 문제에 연관된 핵심 변경사항을 기술해주세요.
--->
코드 한 3줄정도만 바꼈습니다 ..!
disabled 됐을 때 `disabled:bg-zinc-200 disabled:cursor-not-allowed` 하도록 했습니다. 

## 체크리스트 ✅

- [x] `reviewers` 설정
- [x] `assignees` 설정
- [x] `label` 설정
