### PR TITLE
fix: 1차 합격일 때 합격 요청 보낼 수 있도록 수정

### DIFF
--- a/frontend/components/applicant/_applicant/_applicantNode/CustomResource.tsx
+++ b/frontend/components/applicant/_applicant/_applicantNode/CustomResource.tsx
@@ -21,7 +21,7 @@ const CustomResource = ({
   onClickNonPass,
   passState,
 }: CustomResourceProps) => {
-  const isPass = passState === "first-passed" || passState === "final-passed";
+  const isPass = passState === "final-passed";
   const isNonPass = passState === "non-passed";
 
   return (

--- a/frontend/components/applicant/applicantNode/CustomResource.component.tsx
+++ b/frontend/components/applicant/applicantNode/CustomResource.component.tsx
@@ -72,7 +72,7 @@ const ApplicantResource = ({
 
   const passState = getPassState(initialState);
 
-  const isPass = passState === "first-passed" || passState === "final-passed";
+  const isPass = passState === "final-passed";
   const isNonPass = passState === "non-passed";
 
   return (

--- a/frontend/components/passState/ApplicantsList.tsx
+++ b/frontend/components/passState/ApplicantsList.tsx
@@ -121,9 +121,7 @@ const ApplicantsList = ({ sortedBy }: ApplicantsListProps) => {
             </Txt>
             <div className="flex justify-between">
               <button
-                disabled={
-                  passState === "final-passed" || passState === "first-passed"
-                }
+                disabled={passState === "final-passed"}
                 className="border px-4 py-2 rounded-lg truncate hover:bg-primary-100 disabled:bg-primary-100 disabled:cursor-not-allowed"
                 onClick={() =>
                   onChangeApplicantsPassState(name, {


### PR DESCRIPTION
## 관련 이슈

- closes #306 

### 작업 분류

- [x] 버그 수정
- [ ] 신규 기능 추가
- [ ] 프로젝트 구조 변경
- [ ] 코드 스타일 변경
- [ ] 기존 기능 개선
- [ ] 문서 수정

## PR을 통해 해결하려는 문제가 무엇인가요? 🚀

1차 합격일 때 합격 요청 보낼 수 있도록 수정했습니다. 
지난번에 1차 합격일 때와 최종 합격일 때를 같은 api 요청으로 보내는 줄 모르고 수정해버렸네요🥲 다음부터는 신경써서 확인하겠습니다!

## 체크리스트 ✅

- [ ] `reviewers` 설정
- [ ] `assignees` 설정
- [ ] `label` 설정
