### PR TITLE
fix: 개발자 navbar 포트폴리오 입력 전 inactive 하도록 수정

### DIFF
--- a/frontend/src/hooks/useApplication.tsx
+++ b/frontend/src/hooks/useApplication.tsx
@@ -58,6 +58,14 @@ export const useApplication = () => {
         return true;
       }
 
+      // [예외] 포트폴리오 질문 확인
+      if (fieldData == "개발자" && questionId === 12) {
+        const portfolio = localStorage.get<string>("portfolio", "");
+
+        if (portfolio.length === 0) return false;
+        return true;
+      }
+
       // [예외] 필수 확인사항 질문 확인
       if (
         (fieldData == "개발자" && questionId === 13) ||


### PR DESCRIPTION
## 관련 이슈

<!---
  <issue_number>부분을 지우고, 관련 이슈 번호를 작성
--->

- closes #327 

### 작업 분류

<!---
  버그 수정: 버그 수정에 대한 PR일 경우
  신규 기능 추가: 논의된 새로운 기능을 추가하였을 경우
  프로젝트 구조 변경: 디렉터리 구조나 코드 계층(추상화 레벨)이 변경된 경우
  코드 스타일 변경: 린트 규칙, 코딩 컨벤션 등의 변경
  문서 수정: 이슈 템플릿, README, CONTRIBUTE.md 등 프로젝트 관련 문서가 변경될 경우
--->

- [x] 버그 수정
- [ ] 신규 기능 추가
- [ ] 프로젝트 구조 변경
- [ ] 코드 스타일 변경
- [ ] 기존 기능 개선
- [ ] 문서 수정

## PR을 통해 해결하려는 문제가 무엇인가요? 🚀

지원서 페이지에서 개발자의 경우 포트폴리오 필수 입력이 아니라서 첫 화면에서 navbar 가 활성화되어있었습니다.
validation 에 개발자 포트폴리오 추가했습니다.

<img width="368" height="191" alt="image" src="https://github.com/user-attachments/assets/0cfb58ce-57d4-460c-86ce-7d5922e4bdfd" />


## 체크리스트 ✅

- [x] `reviewers` 설정
- [x] `assignees` 설정
- [x] `label` 설정
