### PR TITLE
feat: 합격자 결과 발송 기능 제작 

### DIFF
--- a/frontend/app/(WithNavbar)/pass-state/[generation]/page.tsx
+++ b/frontend/app/(WithNavbar)/pass-state/[generation]/page.tsx
@@ -20,7 +20,7 @@ const PassStatePage = ({ searchParams: { sortedBy } }: PassStatePageProps) => {
       </Txt>
       <div className="mt-8" />
       <BulkEmailButtons />
-      <div className="mt-4" />
+      <div className="mt-10" />
       {sortedBy === "field" && (
         <Link href={`/pass-state/${CURRENT_GENERATION}`}>
           <Txt typography="h5" className="text-secondary-200">

--- a/frontend/app/(WithNavbar)/pass-state/[generation]/page.tsx
+++ b/frontend/app/(WithNavbar)/pass-state/[generation]/page.tsx
@@ -26,7 +26,7 @@ const PassStatePage = ({ searchParams: { sortedBy } }: PassStatePageProps) => {
           <div className="mt-8" />
         </Link>
       )}
-      <div className="grid grid-cols-[8fr_8fr_4fr_3fr] gap-4">
+      <div className="grid grid-cols-[8fr_8fr_4fr_3fr_3fr] gap-4">
         <Txt typography="h6" className="text-left text-secondary-100">
           지원자 이름
         </Txt>
@@ -48,6 +48,12 @@ const PassStatePage = ({ searchParams: { sortedBy } }: PassStatePageProps) => {
         </Link>
         <Txt typography="h6" className="text-left text-secondary-100">
           합격 상태
+        </Txt>
+        <Txt typography="h6" className="text-left text-secondary-100">
+          합격/불합격
+        </Txt>
+        <Txt typography="h6" className="text-left text-secondary-100">
+          이메일 발송
         </Txt>
       </div>
       <div className="mt-2" />

--- a/frontend/app/(WithNavbar)/pass-state/[generation]/page.tsx
+++ b/frontend/app/(WithNavbar)/pass-state/[generation]/page.tsx
@@ -1,5 +1,6 @@
 import Txt from "@/components/common/Txt.component";
 import ApplicantsList from "@/components/passState/ApplicantsList";
+import BulkEmailButtons from "@/components/passState/BulkEmailButtons";
 import { CURRENT_GENERATION } from "@/src/constants";
 import Image from "next/image";
 import Link from "next/link";
@@ -18,6 +19,8 @@ const PassStatePage = ({ searchParams: { sortedBy } }: PassStatePageProps) => {
         {CURRENT_GENERATION}기 지원자 합격 상태 관리 페이지
       </Txt>
       <div className="mt-8" />
+      <BulkEmailButtons />
+      <div className="mt-4" />
       {sortedBy === "field" && (
         <Link href={`/pass-state/${CURRENT_GENERATION}`}>
           <Txt typography="h5" className="text-secondary-200">

--- a/frontend/components/passState/ApplicantsList.tsx
+++ b/frontend/components/passState/ApplicantsList.tsx
@@ -153,7 +153,7 @@ const ApplicantsList = ({ sortedBy }: ApplicantsListProps) => {
           ({ state: { passState }, field, field1, field2, id, name }) => (
             <li
               key={id}
-              className="grid grid-cols-[8fr_8fr_4fr_3fr] gap-4 items-center"
+              className="grid grid-cols-[8fr_8fr_4fr_3fr_3fr] gap-4 items-center"
             >
               <Txt typography="h6" className="text-left truncate">
                 {`[${field}] ${name}`}

--- a/frontend/components/passState/ApplicantsList.tsx
+++ b/frontend/components/passState/ApplicantsList.tsx
@@ -17,6 +17,13 @@ import type {
 } from "@/src/apis/passState";
 import { useOptimisticApplicantPassUpdate } from "@/src/hooks/applicant/useOptimisticApplicantPassUpdate";
 
+const EMAIL_STATE_LABEL_MAP: Record<EmailState, string> = {
+  "first-passed": "1차 합격자",
+  "first-failed": "1차 불합격자",
+  "final-passed": "최종 합격자",
+  "final-failed": "최종 불합격자",
+};
+
 function sortApplicantsByField1(applicants: Answer[]) {
   const passStateOrder = {
     "final-passed": 0,
@@ -73,14 +80,8 @@ const ApplicantsList = ({ sortedBy }: ApplicantsListProps) => {
   };
 
   const onSendEmailAll = (state: EmailState) => {
-    const labelMap: Record<EmailState, string> = {
-      "first-passed": "1차 합격자",
-      "first-failed": "1차 불합격자",
-      "final-passed": "최종 합격자",
-      "final-failed": "최종 불합격자",
-    };
     const ok = confirm(
-      `${labelMap[state]} 전체에게 결과 이메일을 발송하시겠습니까?`
+      `${EMAIL_STATE_LABEL_MAP[state]} 전체에게 결과 이메일을 발송하시겠습니까?`
     );
     if (!ok) return;
     sendEmailAll({ year: Number(selectedGeneration), state });
@@ -136,14 +137,7 @@ const ApplicantsList = ({ sortedBy }: ApplicantsListProps) => {
             className="border px-4 py-2 rounded-lg truncate hover:bg-primary-100"
             onClick={() => onSendEmailAll(state)}
           >
-            {
-              {
-                "first-passed": "1차 합격자",
-                "first-failed": "1차 불합격자",
-                "final-passed": "최종 합격자",
-                "final-failed": "최종 불합격자",
-              }[state]
-            }{" "}
+            {EMAIL_STATE_LABEL_MAP[state]}{" "}
             일괄 발송
           </button>
         ))}

--- a/frontend/components/passState/ApplicantsList.tsx
+++ b/frontend/components/passState/ApplicantsList.tsx
@@ -1,11 +1,16 @@
 "use client";
 
-import { getAllApplicantsWithPassState } from "@/src/apis/passState";
+import {
+  getAllApplicantsWithPassState,
+  sendEmailToApplicant,
+  sendEmailToAll,
+  type EmailState,
+} from "@/src/apis/passState";
 import { CURRENT_GENERATION } from "@/src/constants";
 import { usePathname } from "next/navigation";
 import Txt from "../common/Txt.component";
 import { getApplicantPassState } from "@/src/functions/formatter";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import type {
   PatchApplicantPassStateParams,
   Answer,
@@ -58,6 +63,29 @@ const ApplicantsList = ({ sortedBy }: ApplicantsListProps) => {
     // isLoading: isUpdatingApplicantPassState,
   } = useOptimisticApplicantPassUpdate(selectedGeneration);
 
+  const { mutate: sendEmail } = useMutation(sendEmailToApplicant);
+  const { mutate: sendEmailAll } = useMutation(sendEmailToAll);
+
+  const onSendEmail = (name: string, applicantId: string) => {
+    const ok = confirm(`${name}님에게 결과 이메일을 발송하시겠습니까?`);
+    if (!ok) return;
+    sendEmail(applicantId);
+  };
+
+  const onSendEmailAll = (state: EmailState) => {
+    const labelMap: Record<EmailState, string> = {
+      "first-passed": "1차 합격자",
+      "first-failed": "1차 불합격자",
+      "final-passed": "최종 합격자",
+      "final-failed": "최종 불합격자",
+    };
+    const ok = confirm(
+      `${labelMap[state]} 전체에게 결과 이메일을 발송하시겠습니까?`
+    );
+    if (!ok) return;
+    sendEmailAll({ year: Number(selectedGeneration), state });
+  };
+
   if (+selectedGeneration !== CURRENT_GENERATION) {
     return <div>현재 지원중인 기수만 확인 가능합니다.</div>;
   }
@@ -92,62 +120,101 @@ const ApplicantsList = ({ sortedBy }: ApplicantsListProps) => {
       : allApplicants;
 
   return (
-    <ul className="flex flex-col gap-4">
-      {applicants.map(
-        ({ state: { passState }, field, field1, field2, id, name }) => (
-          <li
-            key={id}
-            className="grid grid-cols-[8fr_8fr_4fr_3fr] gap-4 items-center"
+    <>
+      <div className="flex gap-2 mb-4 flex-wrap">
+        {(
+          [
+            "first-passed",
+            "first-failed",
+            "final-passed",
+            "final-failed",
+          ] as EmailState[]
+        ).map((state) => (
+          <button
+            key={state}
+            type="button"
+            className="border px-4 py-2 rounded-lg truncate hover:bg-primary-100"
+            onClick={() => onSendEmailAll(state)}
           >
-            <Txt typography="h6" className="text-left truncate">
-              {`[${field}] ${name}`}
-            </Txt>
-            <Txt
-              className="text-left truncate"
-              color="gray"
-            >{`${field1}/${field2}`}</Txt>
-            <Txt
-              className="text-left truncate"
-              color={
-                passState === "non-passed"
-                  ? "red"
-                  : passState === "final-passed"
-                  ? "blue"
-                  : "black"
-              }
+            {
+              {
+                "first-passed": "1차 합격자",
+                "first-failed": "1차 불합격자",
+                "final-passed": "최종 합격자",
+                "final-failed": "최종 불합격자",
+              }[state]
+            }{" "}
+            일괄 발송
+          </button>
+        ))}
+      </div>
+      <ul className="flex flex-col gap-4">
+        {applicants.map(
+          ({ state: { passState }, field, field1, field2, id, name }) => (
+            <li
+              key={id}
+              className="grid grid-cols-[8fr_8fr_4fr_3fr] gap-4 items-center"
             >
-              {getApplicantPassState(passState)}
-            </Txt>
-            <div className="flex justify-between">
-              <button
-                disabled={passState === "final-passed"}
-                className="border px-4 py-2 rounded-lg truncate hover:bg-primary-100 disabled:bg-primary-100 disabled:cursor-not-allowed"
-                onClick={() =>
-                  onChangeApplicantsPassState(name, {
-                    applicantId: id,
-                    afterState: "pass",
-                  })
+              <Txt typography="h6" className="text-left truncate">
+                {`[${field}] ${name}`}
+              </Txt>
+              <Txt
+                className="text-left truncate"
+                color="gray"
+              >{`${field1}/${field2}`}</Txt>
+              <Txt
+                className="text-left truncate"
+                color={
+                  passState === "non-passed"
+                    ? "red"
+                    : passState === "final-passed"
+                    ? "blue"
+                    : "black"
                 }
               >
-                합격
-              </button>
+                {getApplicantPassState(passState)}
+              </Txt>
+              <div className="flex justify-between">
+                <button
+                  type="button"
+                  disabled={passState === "final-passed"}
+                  className="border px-4 py-2 rounded-lg truncate hover:bg-primary-100 disabled:bg-primary-100 disabled:cursor-not-allowed"
+                  onClick={() =>
+                    onChangeApplicantsPassState(name, {
+                      applicantId: id,
+                      afterState: "pass",
+                    })
+                  }
+                >
+                  합격
+                </button>
+                <button
+                  type="button"
+                  disabled={passState === "non-passed"}
+                  className="border px-4 rounded-lg truncate hover:bg-primary-100 disabled:bg-primary-100 disabled:cursor-not-allowed"
+                  onClick={() =>
+                    onChangeApplicantsPassState(name, {
+                      applicantId: id,
+                      afterState: "non-pass",
+                    })
+                  }
+                >
+                  불합격
+                </button>
+              </div>
               <button
-                disabled={passState === "non-passed"}
-                className="border px-4 rounded-lg truncate hover:bg-primary-100 disabled:bg-primary-100 disabled:cursor-not-allowed"
-                onClick={() =>
-                  onChangeApplicantsPassState(name, {
-                    applicantId: id,
-                    afterState: "non-pass",
-                  })
-                }
+                type="button"
+                disabled={passState === "non-processed"}
+                className="border px-4 py-2 rounded-lg hover:bg-primary-100 disabled:bg-primary-100 disabled:cursor-not-allowed"
+                onClick={() => onSendEmail(name, id)}
               >
-                불합격
+                발송
               </button>
-            </div>
-          </li>
-        )
-      )}
-    </ul>
+            </li>
+          )
+        )}
+      </ul>
+    </>
   );
 };
 

--- a/frontend/components/passState/ApplicantsList.tsx
+++ b/frontend/components/passState/ApplicantsList.tsx
@@ -3,8 +3,6 @@
 import {
   getAllApplicantsWithPassState,
   sendEmailToApplicant,
-  sendEmailToAll,
-  type EmailState,
 } from "@/src/apis/passState";
 import { CURRENT_GENERATION } from "@/src/constants";
 import { usePathname } from "next/navigation";
@@ -17,12 +15,6 @@ import type {
 } from "@/src/apis/passState";
 import { useOptimisticApplicantPassUpdate } from "@/src/hooks/applicant/useOptimisticApplicantPassUpdate";
 
-const EMAIL_STATE_LABEL_MAP: Record<EmailState, string> = {
-  "first-passed": "1차 합격자",
-  "first-failed": "1차 불합격자",
-  "final-passed": "최종 합격자",
-  "final-failed": "최종 불합격자",
-};
 
 function sortApplicantsByField1(applicants: Answer[]) {
   const passStateOrder = {
@@ -71,20 +63,11 @@ const ApplicantsList = ({ sortedBy }: ApplicantsListProps) => {
   } = useOptimisticApplicantPassUpdate(selectedGeneration);
 
   const { mutate: sendEmail } = useMutation(sendEmailToApplicant);
-  const { mutate: sendEmailAll } = useMutation(sendEmailToAll);
 
   const onSendEmail = (name: string, applicantId: string) => {
     const ok = confirm(`${name}님에게 결과 이메일을 발송하시겠습니까?`);
     if (!ok) return;
     sendEmail(applicantId);
-  };
-
-  const onSendEmailAll = (state: EmailState) => {
-    const ok = confirm(
-      `${EMAIL_STATE_LABEL_MAP[state]} 전체에게 결과 이메일을 발송하시겠습니까?`
-    );
-    if (!ok) return;
-    sendEmailAll({ year: Number(selectedGeneration), state });
   };
 
   if (+selectedGeneration !== CURRENT_GENERATION) {
@@ -122,26 +105,6 @@ const ApplicantsList = ({ sortedBy }: ApplicantsListProps) => {
 
   return (
     <>
-      <div className="flex gap-2 mb-4 flex-wrap">
-        {(
-          [
-            "first-passed",
-            "first-failed",
-            "final-passed",
-            "final-failed",
-          ] as EmailState[]
-        ).map((state) => (
-          <button
-            key={state}
-            type="button"
-            className="border px-4 py-2 rounded-lg hover:bg-primary-100"
-            onClick={() => onSendEmailAll(state)}
-          >
-            {EMAIL_STATE_LABEL_MAP[state]}{" "}
-            일괄 발송
-          </button>
-        ))}
-      </div>
       <ul className="flex flex-col gap-4">
         {applicants.map(
           ({ state: { passState }, field, field1, field2, id, name }) => (

--- a/frontend/components/passState/ApplicantsList.tsx
+++ b/frontend/components/passState/ApplicantsList.tsx
@@ -27,7 +27,7 @@ function sortApplicantsByField1(applicants: Answer[]) {
     GAME: 3,
   };
 
-  return applicants.sort((a, b) => {
+  return [...applicants].sort((a, b) => {
     if (
       passStateOrder[a.state.passState] !== passStateOrder[b.state.passState]
     ) {
@@ -58,30 +58,29 @@ const ApplicantsList = ({ sortedBy }: ApplicantsListProps) => {
     // isLoading: isUpdatingApplicantPassState,
   } = useOptimisticApplicantPassUpdate(selectedGeneration);
 
-  {
-    if (+selectedGeneration !== CURRENT_GENERATION) {
-      return <div>현재 지원중인 기수만 확인 가능합니다.</div>;
-    }
+  if (+selectedGeneration !== CURRENT_GENERATION) {
+    return <div>현재 지원중인 기수만 확인 가능합니다.</div>;
+  }
 
-    if (isLoading) {
-      return <div>Loading...</div>;
-    }
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
 
-    if (isError) {
-      return <div>Error</div>;
-    }
+  if (isError) {
+    return <div>Error</div>;
+  }
 
-    if (!allApplicants) {
-      return <div>아직은 지원자가 없습니다 🥲</div>;
-    }
+  if (!allApplicants) {
+    return <div>아직은 지원자가 없습니다 🥲</div>;
   }
 
   const onChangeApplicantsPassState = (
     applicantName: string,
     params: PatchApplicantPassStateParams
   ) => {
+    const stateLabel = params.afterState === "pass" ? "합격" : "불합격";
     const ok = confirm(
-      `${applicantName}님을 ${params.afterState} 처리하시겠습니까?`
+      `${applicantName}님을 ${stateLabel} 처리하시겠습니까?`
     );
     if (!ok) return;
     updateApplicantPassState(params);

--- a/frontend/components/passState/ApplicantsList.tsx
+++ b/frontend/components/passState/ApplicantsList.tsx
@@ -134,7 +134,7 @@ const ApplicantsList = ({ sortedBy }: ApplicantsListProps) => {
           <button
             key={state}
             type="button"
-            className="border px-4 py-2 rounded-lg truncate hover:bg-primary-100"
+            className="border px-4 py-2 rounded-lg hover:bg-primary-100"
             onClick={() => onSendEmailAll(state)}
           >
             {EMAIL_STATE_LABEL_MAP[state]}{" "}

--- a/frontend/components/passState/BulkEmailButtons.tsx
+++ b/frontend/components/passState/BulkEmailButtons.tsx
@@ -33,7 +33,7 @@ const BulkEmailButtons = () => {
 
   return (
     <div className="flex flex-col gap-2">
-      <h6 className="text-sm font-semibold text-secondary-100">일괄 발송</h6>
+      <h6 className="text-base font-bold text-secondary-100">일괄 발송</h6>
       <div className="flex gap-2 flex-wrap">
         {EMAIL_STATES.map((state) => (
           <button

--- a/frontend/components/passState/BulkEmailButtons.tsx
+++ b/frontend/components/passState/BulkEmailButtons.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { sendEmailToAll, type EmailState } from "@/src/apis/passState";
+import { useMutation } from "@tanstack/react-query";
+import { usePathname } from "next/navigation";
+
+const EMAIL_STATE_LABEL_MAP: Record<EmailState, string> = {
+  "first-passed": "1차 합격자",
+  "first-failed": "1차 불합격자",
+  "final-passed": "최종 합격자",
+  "final-failed": "최종 불합격자",
+};
+
+const BulkEmailButtons = () => {
+  const selectedGeneration = usePathname().split("/")[2];
+  const { mutate: sendEmailAll } = useMutation(sendEmailToAll);
+
+  const onSendEmailAll = (state: EmailState) => {
+    const ok = confirm(
+      `${EMAIL_STATE_LABEL_MAP[state]} 전체에게 결과 이메일을 발송하시겠습니까?`
+    );
+    if (!ok) return;
+    sendEmailAll({ year: Number(selectedGeneration), state });
+  };
+
+  return (
+    <div className="flex gap-2 flex-wrap">
+      {(
+        [
+          "first-passed",
+          "first-failed",
+          "final-passed",
+          "final-failed",
+        ] as EmailState[]
+      ).map((state) => (
+        <button
+          key={state}
+          type="button"
+          className="border px-4 py-2 rounded-lg hover:bg-primary-100"
+          onClick={() => onSendEmailAll(state)}
+        >
+          {EMAIL_STATE_LABEL_MAP[state]} 일괄 발송
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default BulkEmailButtons;

--- a/frontend/components/passState/BulkEmailButtons.tsx
+++ b/frontend/components/passState/BulkEmailButtons.tsx
@@ -11,6 +11,8 @@ const EMAIL_STATE_LABEL_MAP: Record<EmailState, string> = {
   "final-failed": "최종 불합격자",
 };
 
+const EMAIL_STATES = Object.keys(EMAIL_STATE_LABEL_MAP) as EmailState[];
+
 const BulkEmailButtons = () => {
   const selectedGeneration = usePathname().split("/")[2];
   const { mutate: sendEmailAll } = useMutation(sendEmailToAll);
@@ -25,14 +27,7 @@ const BulkEmailButtons = () => {
 
   return (
     <div className="flex gap-2 flex-wrap">
-      {(
-        [
-          "first-passed",
-          "first-failed",
-          "final-passed",
-          "final-failed",
-        ] as EmailState[]
-      ).map((state) => (
+      {EMAIL_STATES.map((state) => (
         <button
           key={state}
           type="button"

--- a/frontend/components/passState/BulkEmailButtons.tsx
+++ b/frontend/components/passState/BulkEmailButtons.tsx
@@ -22,21 +22,30 @@ const BulkEmailButtons = () => {
       `${EMAIL_STATE_LABEL_MAP[state]} 전체에게 결과 이메일을 발송하시겠습니까?`
     );
     if (!ok) return;
-    sendEmailAll({ year: Number(selectedGeneration), state });
+    sendEmailAll(
+      { year: Number(selectedGeneration), state },
+      {
+        onSuccess: () => alert(`${EMAIL_STATE_LABEL_MAP[state]} 이메일 발송이 완료되었습니다.`),
+        onError: () => alert(`이메일 발송 중 오류가 발생했습니다. 다시 시도해주세요.`),
+      }
+    );
   };
 
   return (
-    <div className="flex gap-2 flex-wrap">
-      {EMAIL_STATES.map((state) => (
-        <button
-          key={state}
-          type="button"
-          className="border px-4 py-2 rounded-lg hover:bg-primary-100"
-          onClick={() => onSendEmailAll(state)}
-        >
-          {EMAIL_STATE_LABEL_MAP[state]} 일괄 발송
-        </button>
-      ))}
+    <div className="flex flex-col gap-2">
+      <h6 className="text-sm font-semibold text-secondary-100">일괄 발송</h6>
+      <div className="flex gap-2 flex-wrap">
+        {EMAIL_STATES.map((state) => (
+          <button
+            key={state}
+            type="button"
+            className="border px-4 py-2 rounded-lg hover:bg-primary-100"
+            onClick={() => onSendEmailAll(state)}
+          >
+            {EMAIL_STATE_LABEL_MAP[state]} 일괄 발송
+          </button>
+        ))}
+      </div>
     </div>
   );
 };

--- a/frontend/src/apis/passState/index.tsx
+++ b/frontend/src/apis/passState/index.tsx
@@ -34,3 +34,23 @@ export const patchApplicantPassState = async ({
     `/applicants/${applicantId}/state?afterState=${afterState}`
   );
 };
+
+export const sendEmailToApplicant = async (applicantId: string) => {
+  await https.post<void>(`/emails/${applicantId}`);
+};
+
+export type EmailState =
+  | "first-passed"
+  | "first-failed"
+  | "final-passed"
+  | "final-failed";
+
+export interface SendEmailToAllParams {
+  year: number;
+  state: EmailState;
+}
+export const sendEmailToAll = async ({ year, state }: SendEmailToAllParams) => {
+  await https.post<void>(`/emails/all`, undefined, {
+    params: { year, state },
+  });
+};

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -174,6 +174,7 @@ export const needValidatePath = [
   "/applicant",
   "/interview",
   "/kanban",
+  "/pass-state",
 ];
 
 export const MAX_BOOLEAN_TEXT_LENGTH = 800;


### PR DESCRIPTION
### 작업 분류

<!---
  버그 수정: 버그 수정에 대한 PR일 경우
  신규 기능 추가: 논의된 새로운 기능을 추가하였을 경우
  프로젝트 구조 변경: 디렉터리 구조나 코드 계층(추상화 레벨)이 변경된 경우
  코드 스타일 변경: 린트 규칙, 코딩 컨벤션 등의 변경
  문서 수정: 이슈 템플릿, README, CONTRIBUTE.md 등 프로젝트 관련 문서가 변경될 경우
--->

- [x] 버그 수정
- [x] 신규 기능 추가
- [ ] 프로젝트 구조 변경
- [ ] 코드 스타일 변경
- [ ] 기존 기능 개선
- [ ] 문서 수정

## PR을 통해 해결하려는 문제가 무엇인가요? 🚀

합격 상태 관리 페이지에서 지원자에게 결과 이메일을 발송하는 기능이 없었습니다.
또한 기존 코드에 배열 원본 변이, early return 블록 스코프 오류, 확인 메시지 영문 노출 등의 버그가 존재했습니다.

## PR에서 핵심적으로 변경된 부분이 어떤 부분인가요? 👀

- 개별 지원자에게 결과 이메일 발송 버튼 추가 (non-processed 상태일 때 비활성화)
- 1차 합격자 / 1차 불합격자 / 최종 합격자 / 최종 불합격자 일괄 이메일 발송 버튼 추가
- sendEmailToApplicant, sendEmailToAll API 함수 추가 (/emails/{id}, /emails/all)

## 핵심 변경사항 이외 추가적으로 변경된 사항이 있나요? ➕

- sortApplicantsByField1에서 [...applicants].sort()로 변경하여 react-query 캐시 원본 배열 변이 방지
- 불필요한 블록 스코프 {} 제거 및 early return 정리
- 합격/불합격 처리 confirm 메시지 영문(pass/non-pass) → 한글(합격/불합격) 수정
- 헤더 컬럼과 리스트 컬럼 불일치 수정 (4컬럼 → 5컬럼, 합격/불합격 · 이메일 발송 헤더 추가)
- 발송 버튼 truncate 클래스 제거로 텍스트 잘림 현상 수정

## 추가적으로, 리뷰어가 리뷰하며 알아야 할 정보가 있나요? 🙌


## 이런 부분을 신경써서 봐주셨으면 좋겠어요. 🙋🏻‍♂️

일괄 발송 시 재발송 방지 로직이 없어 중복 발송이 가능한 상태인데, 
이 부분을 어떻게 처리할지 의견 부탁드립니다.

## 체크리스트 ✅

- [x] `reviewers` 설정
- [x] `assignees` 설정
- [x] `label` 설정
