### PR TITLE
fix: 합격 상태 및 칸반 UI 갱신 오류 수정

### DIFF
--- a/frontend/src/apis/passState/index.tsx
+++ b/frontend/src/apis/passState/index.tsx
@@ -26,13 +26,20 @@ export interface PatchApplicantPassStateParams {
   applicantId: string;
   afterState: "non-pass" | "pass";
 }
+
+export interface PatchApplicantPassStateResponse {
+  passState: ApplicantPassState;
+}
+
 export const patchApplicantPassState = async ({
   afterState,
   applicantId,
 }: PatchApplicantPassStateParams) => {
-  await https.patch(
+  const { data } = await https.patch<PatchApplicantPassStateResponse>(
     `/applicants/${applicantId}/state?afterState=${afterState}`
   );
+
+  return data;
 };
 
 export const sendEmailToApplicant = async (applicantId: string) => {

--- a/frontend/src/hooks/applicant/useOptimisticApplicantPassUpdate.tsx
+++ b/frontend/src/hooks/applicant/useOptimisticApplicantPassUpdate.tsx
@@ -23,39 +23,32 @@ export const useOptimisticApplicantPassUpdate = (generation: string) => {
   return useMutation({
     mutationFn: (params: PatchApplicantPassStateParams) =>
       patchApplicantPassState(params),
-    onMutate: async (params) => {
-      await queryClient.cancelQueries({
-        queryKey: ["allApplicantsWithPassState", generation],
-      });
-
-      const previousData = queryClient.getQueryData([
-        "allApplicantsWithPassState",
-        generation,
-      ]);
-
-      queryClient.setQueryData(
+    onSuccess: ({ passState }, params) => {
+      queryClient.setQueryData<ApplicantPartialRes[]>(
         ["allApplicantsWithPassState", generation],
-        (oldData: ApplicantPartialRes[] | undefined) => {
+        (oldData) => {
           if (!oldData) return oldData;
-          return oldData.map((applicant: ApplicantPartialRes) =>
+
+          return oldData.map((applicant) =>
             applicant.id === params.applicantId
-              ? { ...applicant, passState: params.afterState }
+              ? {
+                  ...applicant,
+                  state: {
+                    ...applicant.state,
+                    passState,
+                  },
+                }
               : applicant
           );
         }
-      );
-
-      return { previousData };
-    },
-    onError: (err, variables, context) => {
-      queryClient.setQueryData(
-        ["allApplicantsWithPassState", generation],
-        context?.previousData
       );
     },
     onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: ["allApplicantsWithPassState", generation],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["kanbanDataArray"],
       });
     },
   });


### PR DESCRIPTION
## 작업 분류                                                                            
                                                                                          
  - [x] 버그 수정                                                                         
                                                                                          
  ## PR을 통해 해결하려는 문제가 무엇인가요? 🚀                                           
                                                                                          
  지원자를 합격 또는 불합격 처리해도 상태 배지와 칸반 카드 색상이 즉시 갱신되지 않는 문제 
  가 있었습니다.                                                                          
                                                                                          
  백엔드에서 변경된 `passState`를 정상적으로 반환하고 있었지만, 프론트에서 응답을 사용하지
  않고 잘못된 캐시 위치에 상태를 저장하고 있었습니다.                                     
                                                                                          
  ## PR에서 핵심적으로 변경된 부분이 어떤 부분인가요? 👀                                  
                                                                                          
  - 합격 상태 변경 API의 응답값을 반환하도록 수정                                         
  - 백엔드에서 받은 `passState`를 `state.passState`에 반영                                
  - 상태 변경 후 지원자 목록과 칸반 데이터를 다시 조회하도록 수정                         
  - `1차 합격`, `최종 합격`, `탈락` 배지 및 색상이 정상적으로 갱신되도록 개선   