### PR TITLE
revert: 합격 상태 및 칸반 UI 갱신 로직 원복 

### DIFF
--- a/frontend/src/apis/passState/index.tsx
+++ b/frontend/src/apis/passState/index.tsx
@@ -26,20 +26,13 @@ export interface PatchApplicantPassStateParams {
   applicantId: string;
   afterState: "non-pass" | "pass";
 }
-
-export interface PatchApplicantPassStateResponse {
-  passState: ApplicantPassState;
-}
-
 export const patchApplicantPassState = async ({
   afterState,
   applicantId,
 }: PatchApplicantPassStateParams) => {
-  const { data } = await https.patch<PatchApplicantPassStateResponse>(
+  await https.patch(
     `/applicants/${applicantId}/state?afterState=${afterState}`
   );
-
-  return data;
 };
 
 export const sendEmailToApplicant = async (applicantId: string) => {

--- a/frontend/src/hooks/applicant/useOptimisticApplicantPassUpdate.tsx
+++ b/frontend/src/hooks/applicant/useOptimisticApplicantPassUpdate.tsx
@@ -23,32 +23,39 @@ export const useOptimisticApplicantPassUpdate = (generation: string) => {
   return useMutation({
     mutationFn: (params: PatchApplicantPassStateParams) =>
       patchApplicantPassState(params),
-    onSuccess: ({ passState }, params) => {
-      queryClient.setQueryData<ApplicantPartialRes[]>(
-        ["allApplicantsWithPassState", generation],
-        (oldData) => {
-          if (!oldData) return oldData;
+    onMutate: async (params) => {
+      await queryClient.cancelQueries({
+        queryKey: ["allApplicantsWithPassState", generation],
+      });
 
-          return oldData.map((applicant) =>
+      const previousData = queryClient.getQueryData([
+        "allApplicantsWithPassState",
+        generation,
+      ]);
+
+      queryClient.setQueryData(
+        ["allApplicantsWithPassState", generation],
+        (oldData: ApplicantPartialRes[] | undefined) => {
+          if (!oldData) return oldData;
+          return oldData.map((applicant: ApplicantPartialRes) =>
             applicant.id === params.applicantId
-              ? {
-                  ...applicant,
-                  state: {
-                    ...applicant.state,
-                    passState,
-                  },
-                }
+              ? { ...applicant, passState: params.afterState }
               : applicant
           );
         }
+      );
+
+      return { previousData };
+    },
+    onError: (err, variables, context) => {
+      queryClient.setQueryData(
+        ["allApplicantsWithPassState", generation],
+        context?.previousData
       );
     },
     onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: ["allApplicantsWithPassState", generation],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ["kanbanDataArray"],
       });
     },
   });


### PR DESCRIPTION
  ## PR을 통해 해결하려는 문제가 무엇인가요? 🚀                                           
                                                                                          
  합격/불합격 상태가 변경되지 않는 원인을 프론트 상태 동기화 문제로 판단하여 수정했으나,  
  실제 원인은 백엔드에서 상태 변경 가능 기간을 제한하고 있었던 것이었습니다.              
                                                                                          
  이에 불필요하게 적용된 PR #346의 프론트 변경사항을 원복합니다.                          
                                                                                          
  ## PR에서 핵심적으로 변경된 부분이 어떤 부분인가요? 👀                                  
                                                                                          
  - 합격 상태 변경 API의 응답값을 직접 반영하던 로직 원복                                 
  - 지원자 목록 및 칸반 캐시 갱신 로직 원복                                               
  - PR #346 적용 이전 상태로 복구    

  ## 추가적으로, 리뷰어가 리뷰하며 알아야 할 정보가 있나요? 🙌                            
                                                                                          
  실제 상태 변경 실패 원인은 프론트가 아니라 백엔드의 심사 기간 제한이었습니다.                                                       